### PR TITLE
Feature/tri 377

### DIFF
--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -76,12 +76,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <version>${spotbugs.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>net.catenax.irs</groupId>
             <artifactId>irs-testing</artifactId>
             <version>${revision}</version>

--- a/irs-common/pom.xml
+++ b/irs-common/pom.xml
@@ -18,11 +18,5 @@
 
     <dependencies>
         <!-- Should not add any library dependencies in this module, except annotations in provided scope -->
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <version>${spotbugs.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/irs-models/pom.xml
+++ b/irs-models/pom.xml
@@ -18,12 +18,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <version>${spotbugs.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
             <exclusions>

--- a/irs-models/src/main/java/net/catenax/irs/dtos/ErrorResponse.java
+++ b/irs-models/src/main/java/net/catenax/irs/dtos/ErrorResponse.java
@@ -12,7 +12,6 @@ package net.catenax.irs.dtos;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Value;
@@ -24,7 +23,6 @@ import org.springframework.http.HttpStatus;
 @Builder(toBuilder = true, setterPrefix = "with")
 @JsonDeserialize(builder = ErrorResponse.ErrorResponseBuilder.class)
 @SuppressWarnings("PMD.CommentRequired")
-@SuppressFBWarnings(value = "UUF_UNUSED_FIELD", justification = "DTO, values are used by API clients.")
 public class ErrorResponse {
     @Schema(description = "Error code.")
     private HttpStatus statusCode;

--- a/lombok.config
+++ b/lombok.config
@@ -1,5 +1,2 @@
 # Add @Generated annotation to generated code, so that it is skipped by JaCoCo
 lombok.addLombokGeneratedAnnotation = true
-
-# Add @SuppressFBWarnings annotation to generated code, so that it is skipped by SpotBugs
-lombok.extern.findbugs.addSuppressFBWarnings = true


### PR DESCRIPTION
- spotbugs-annotations removed as it was used only in one place, but was not necessary there anyway
- spotbugs-maven-plugin is still there in irs-parent/pom.xml - should I remove also the plugin?