### PR TITLE
Fix/tri 435

### DIFF
--- a/.github/workflows/CI-branches.yml
+++ b/.github/workflows/CI-branches.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - 'feature/**'
       - 'bugfix/**'
+      - 'fix/**'
+      - 'chore/**'
 
 jobs:
   build:

--- a/.github/workflows/CI-branches.yml
+++ b/.github/workflows/CI-branches.yml
@@ -32,3 +32,17 @@ jobs:
         run: |
           mvn --batch-mode --update-snapshots -s settings.xml verify
 
+  build_images:
+    strategy:
+      matrix:
+        image:
+          - irs-api
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build image to make sure Dockerfile is valid
+        run: |
+          # RUN --mount=type=cache is used in the IRS Dockerfile to cache directories for maven.
+          # And the --mount option requires BuildKit.
+          DOCKER_BUILDKIT=1 docker build --build-arg BUILD_TARGET=${{ matrix.image }} --target ${{ matrix.image }} -t ${{ matrix.image }}:latest .

--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 FROM maven:3-openjdk-17 AS maven
 ARG BUILD_TARGET=irs-api
 
-USER 1000
-
 WORKDIR /build
 
 COPY ci ci
@@ -28,10 +26,13 @@ RUN --mount=type=cache,target=/root/.m2 mvn -B -s settings.xml clean package -pl
 # Copy the jar and build image
 FROM eclipse-temurin:18-jre AS irs-api
 
-USER 1000
+ARG UID=1000
+ARG GID=1000
 
 WORKDIR /app
 
-COPY --from=maven /build/irs-api/target/irs-api-*-exec.jar app.jar
+COPY --chown=${UID}:${GID} --from=maven /build/irs-api/target/irs-api-*-exec.jar app.jar
+
+USER ${UID}:${GID}
 
 ENTRYPOINT ["java", "-Djava.util.logging.config.file=./logging.properties", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM maven:3-openjdk-17 AS maven
 ARG BUILD_TARGET=irs-api
 
+USER 1000
+
 WORKDIR /build
 
 COPY ci ci
@@ -25,6 +27,8 @@ RUN --mount=type=cache,target=/root/.m2 mvn -B -s settings.xml clean package -pl
 
 # Copy the jar and build image
 FROM eclipse-temurin:18-jre AS irs-api
+
+USER 1000
 
 WORKDIR /app
 


### PR DESCRIPTION
Using non-root user when running the IRS in docker now.
Also validating the Dockerfile build in branches and avoiding duplicate builds for pull requests.