### PR TITLE
Feature/tri 395

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ The two following subsections provide instructions for running either only the i
 * This will start additional containers:
   * [Prometheus](https://prometheus.io/docs/introduction/overview/), a server to collect and query metrics. Prometheus is available at http://localhost:9091/.
 
+## Keycloak authentication
+
+Access token is required to access every IRS endpoint and should be included in Authorization header for all requests - otherwise 401 Unauthorized status is returned to client. 
+To obtain access token prepared [Postman collection can be used](testing/IRS DEMO Collection.postman_collection.json)
+
 ## Work with sample data
 
 * Retrieve sample BOM:
@@ -35,6 +40,7 @@ curl -X 'POST' \
   'http://localhost:8080/irs/jobs' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <<token_value>>' \
   -d '{
   "aspects": [
     "SerialPartTypization"
@@ -45,7 +51,7 @@ curl -X 'POST' \
   "globalAssetId": "urn:uuid:8a61c8db-561e-4db0-84ec-a693fc5ffdf6"
 }'
   
-curl -X 'GET'  'http://localhost:8080/irs/jobs/<jobID from first call>' -H 'accept: application/json'
+curl -X 'GET'  'http://localhost:8080/irs/jobs/<jobID from first call>' -H 'accept: application/json' -H 'Authorization: Bearer <<token_value>>'
 ```
 
 ## Swagger UI

--- a/chart/irs/templates/deployment.yaml
+++ b/chart/irs/templates/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: {{ .Values.keycloak.oauth2.clientSecret }}
             - name: KEYCLOAK_OAUTH2_CLIENT_TOKEN_URI
               value: {{ .Values.keycloak.oauth2.clientTokenUri }}
+            - name: KEYCLOAK_OAUTH2_JWK_SET_URI
+              value: {{ .Values.keycloak.oauth2.jwkSetUri }}
           ports:
             - name: http
               containerPort: 8080

--- a/chart/irs/values.yaml
+++ b/chart/irs/values.yaml
@@ -110,3 +110,4 @@ keycloak:
     clientId: <path:product-traceability-irs/data/int/keycloak/oauth2#clientId>
     clientSecret: <path:product-traceability-irs/data/int/keycloak/oauth2#clientSecret>
     clientTokenUri: <path:product-traceability-irs/data/int/keycloak/oauth2#tokenUri>
+    jwkSetUri: <path:product-traceability-irs/data/int/keycloak/oauth2#jwkSetUri>

--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
@@ -87,6 +91,11 @@
             <groupId>net.catenax.irs</groupId>
             <artifactId>irs-testing</artifactId>
             <version>${revision}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/irs-api/src/main/java/net/catenax/irs/configuration/OAuthRestTemplateConfig.java
+++ b/irs-api/src/main/java/net/catenax/irs/configuration/OAuthRestTemplateConfig.java
@@ -46,7 +46,7 @@ public class OAuthRestTemplateConfig {
     public static final String OAUTH_REST_TEMPLATE = "oAuthRestTemplate";
 
     private static final String CLIENT_REGISTRATION_ID = "keycloak";
-    private static final int TIMEOUT = 5;
+    private static final int TIMEOUT_SECONDS = 5;
 
     private final OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
     private final ClientRegistrationRepository clientRegistrationRepository;
@@ -57,8 +57,8 @@ public class OAuthRestTemplateConfig {
 
         return restTemplateBuilder
                 .additionalInterceptors(new OAuthClientCredentialsRestTemplateInterceptor(authorizedClientManager(), clientRegistration))
-                .setReadTimeout(Duration.ofSeconds(TIMEOUT))
-                .setConnectTimeout(Duration.ofSeconds(TIMEOUT))
+                .setReadTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
+                .setConnectTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
                 .build();
     }
 

--- a/irs-api/src/main/java/net/catenax/irs/configuration/SecurityConfiguration.java
+++ b/irs-api/src/main/java/net/catenax/irs/configuration/SecurityConfiguration.java
@@ -9,25 +9,50 @@
 //
 package net.catenax.irs.configuration;
 
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 
 /**
  * Security config bean
  */
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    private static final String[] WHITELIST  = {
+        "/actuator/health",
+        "/api/swagger-ui/index.html",
+        "/api/api-docs",
+        "/api/api-docs.yaml"
+    };
 
     @Override
     protected void configure(final HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.httpBasic().disable();
+        httpSecurity.formLogin().disable();
+        httpSecurity.csrf().disable();
+        httpSecurity.logout().disable();
+        httpSecurity.cors().disable();
+
         httpSecurity
-            .csrf().disable()
+            .sessionManagement()
+            .sessionCreationPolicy(STATELESS)
+            .and()
             .authorizeRequests()
-            .antMatchers("/**").permitAll()
-            .and().oauth2Client();
+            .antMatchers(WHITELIST)
+            .permitAll()
+            .antMatchers("/**")
+            .authenticated()
+            .and()
+            .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
+            .oauth2Client();
     }
 
 }

--- a/irs-api/src/main/java/net/catenax/irs/configuration/SecurityConfiguration.java
+++ b/irs-api/src/main/java/net/catenax/irs/configuration/SecurityConfiguration.java
@@ -51,7 +51,7 @@ class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers(WHITELIST)
             .permitAll()
             .antMatchers("/**")
-            .permitAll()
+            .authenticated()
             .and()
             .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
             .oauth2Client();

--- a/irs-api/src/main/java/net/catenax/irs/configuration/SecurityConfiguration.java
+++ b/irs-api/src/main/java/net/catenax/irs/configuration/SecurityConfiguration.java
@@ -28,9 +28,11 @@ class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private static final String[] WHITELIST  = {
         "/actuator/health",
-        "/api/swagger-ui/index.html",
+        "/actuator/prometheus",
+        "/api/swagger-ui/**",
         "/api/api-docs",
-        "/api/api-docs.yaml"
+        "/api/api-docs.yaml",
+        "/api/api-docs/swagger-config",
     };
 
     @Override
@@ -49,7 +51,7 @@ class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers(WHITELIST)
             .permitAll()
             .antMatchers("/**")
-            .authenticated()
+            .permitAll()
             .and()
             .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
             .oauth2Client();

--- a/irs-api/src/main/java/net/catenax/irs/services/IrsItemGraphQueryService.java
+++ b/irs-api/src/main/java/net/catenax/irs/services/IrsItemGraphQueryService.java
@@ -90,10 +90,7 @@ public class IrsItemGraphQueryService implements IIrsItemGraphQueryService {
         final int treeDepth = request.getDepth();
         final Optional<BomLifecycle> bomLifecycleFormRequest = Optional.ofNullable(request.getBomLifecycle());
 
-        String lifecycle = null;
-        if (bomLifecycleFormRequest.isPresent()) {
-            lifecycle = bomLifecycleFormRequest.get().getLifecycleContextCharacteristicValue();
-        }
+        final String lifecycle = bomLifecycleFormRequest.map(BomLifecycle::getLifecycleContextCharacteristicValue).orElse(null);
 
         final Optional<List<AspectType>> aspectTypes = Optional.ofNullable(request.getAspects());
         List<String> aspectTypeValues;

--- a/irs-api/src/main/resources/application-local.yml
+++ b/irs-api/src/main/resources/application-local.yml
@@ -9,4 +9,3 @@ irs:
       scheduler:
         completed: 0 * * * * *
         failed: 0 * * * * *
-

--- a/irs-api/src/main/resources/application-local.yml
+++ b/irs-api/src/main/resources/application-local.yml
@@ -9,3 +9,10 @@ irs:
       scheduler:
         completed: 0 * * * * *
         failed: 0 * * * * *
+
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: https://catenaxintakssrv.germanywestcentral.cloudapp.azure.com/iamcentralidp/auth/realms/CX-Central/protocol/openid-connect/certs

--- a/irs-api/src/main/resources/application.yml
+++ b/irs-api/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
             token-uri: ${KEYCLOAK_OAUTH2_CLIENT_TOKEN_URI}
       resourceserver:
         jwt:
-          jwk-set-uri: https://catenaxintakssrv.germanywestcentral.cloudapp.azure.com/iamcentralidp/auth/realms/CX-Central/protocol/openid-connect/certs
+          jwk-set-uri: ${KEYCLOAK_OAUTH2_JWK_SET_URI}
 
 management:
   endpoints:

--- a/irs-api/src/main/resources/application.yml
+++ b/irs-api/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
         provider:
           keycloak:
             token-uri: ${KEYCLOAK_OAUTH2_CLIENT_TOKEN_URI}
+      resourceserver:
+        jwt:
+          jwk-set-uri: https://catenaxintakssrv.germanywestcentral.cloudapp.azure.com/iamcentralidp/auth/realms/CX-Central/protocol/openid-connect/certs
 
 management:
   endpoints:

--- a/irs-api/src/main/resources/application.yml
+++ b/irs-api/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
             token-uri: ${KEYCLOAK_OAUTH2_CLIENT_TOKEN_URI}
       resourceserver:
         jwt:
-          jwk-set-uri: ${KEYCLOAK_OAUTH2_JWK_SET_URI}
+          jwk-set-uri: ${KEYCLOAK_OAUTH2_JWK_SET_URI:https://default}
 
 management:
   endpoints:

--- a/irs-api/src/test/java/net/catenax/irs/controllers/IrsControllerTest.java
+++ b/irs-api/src/test/java/net/catenax/irs/controllers/IrsControllerTest.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(IrsController.class)
@@ -52,6 +53,7 @@ class IrsControllerTest {
     }
 
     @Test
+    @WithMockUser
     void initiateJobForGlobalAssetId() throws Exception {
         final UUID returnedJob = UUID.randomUUID();
         when(service.registerItemJob(any())).thenReturn(JobHandle.builder().jobId(returnedJob).build());
@@ -65,6 +67,7 @@ class IrsControllerTest {
 
     @ParameterizedTest
     @MethodSource("corruptedJobs")
+    @WithMockUser
     void shouldReturnBadRequestWhenRegisterJobBodyNotValid(final RegisterJob registerJob) throws Exception {
         this.mockMvc.perform(post("/irs/jobs").contentType(MediaType.APPLICATION_JSON)
                                               .content(new ObjectMapper().writeValueAsString(registerJob)))
@@ -72,11 +75,7 @@ class IrsControllerTest {
     }
 
     @Test
-    void getJobById() {
-        assertTrue(true);
-    }
-
-    @Test
+    @WithMockUser
     void getJobsByJobState() throws Exception {
         final UUID returnedJob = UUID.randomUUID();
         when(service.getJobsByJobState(any())).thenReturn(List.of(returnedJob));
@@ -87,6 +86,7 @@ class IrsControllerTest {
     }
 
     @Test
+    @WithMockUser
     void cancelJobById() throws Exception {
         final Job canceledJob = Job.builder().jobId(jobId).jobState(JobState.CANCELED).build();
 
@@ -96,6 +96,7 @@ class IrsControllerTest {
     }
 
     @Test
+    @WithMockUser
     void cancelJobById_throwEntityNotFoundException() throws Exception {
         given(this.service.cancelJobById(jobId)).willThrow(
                 new EntityNotFoundException("No job exists with id " + jobId));


### PR DESCRIPTION
- secure our API by Keycloak access token,
- every endpoint besides WHITELIST is protected. Should I temporary permit all endpoints to let developer know, or its fine like this?
Temporary solution would be like this:
`.antMatchers("/**").permitAll()`
