### PR TITLE
feat(impl):[TRI-445] new rest template

### DIFF
--- a/chart/irs/templates/deployment.yaml
+++ b/chart/irs/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
               value: {{ .Values.keycloak.oauth2.clientTokenUri }}
             - name: KEYCLOAK_OAUTH2_JWK_SET_URI
               value: {{ .Values.keycloak.oauth2.jwkSetUri }}
+            - name: AAS_PROXY_SUBMODEL_USERNAME
+              value: {{ .Values.aasProxy.submodel.username }}
+            - name: AAS_PROXY_SUBMODEL_PASSWORD
+              value: {{ .Values.aasProxy.submodel.password }}
           ports:
             - name: http
               containerPort: 8080

--- a/chart/irs/values-dev.yaml
+++ b/chart/irs/values-dev.yaml
@@ -9,3 +9,8 @@ keycloak:
     clientSecret: <path:product-traceability-irs/data/dev/keycloak/oauth2#clientSecret>
     clientTokenUri: <path:product-traceability-irs/data/dev/keycloak/oauth2#tokenUri>
     jwkSetUri: <path:product-traceability-irs/data/dev/keycloak/oauth2#jwkSetUri>
+
+aasProxy:
+  submodel:
+    username: <path:product-traceability-irs/data/dev/aasProxy/submodel#username>
+    password: <path:product-traceability-irs/data/dev/aasProxy/submodel#password>

--- a/chart/irs/values-int.yaml
+++ b/chart/irs/values-int.yaml
@@ -21,3 +21,8 @@ keycloak:
     clientSecret: <path:product-traceability-irs/data/int/keycloak/oauth2#clientSecret>
     clientTokenUri: <path:product-traceability-irs/data/int/keycloak/oauth2#tokenUri>
     jwkSetUri: <path:product-traceability-irs/data/int/keycloak/oauth2#jwkSetUri>
+
+aasProxy:
+  submodel:
+    username: <path:product-traceability-irs/data/int/aasProxy/submodel#username>
+    password: <path:product-traceability-irs/data/int/aasProxy/submodel#password>

--- a/irs-api/src/main/java/net/catenax/irs/aaswrapper/registry/domain/DigitalTwinRegistryClient.java
+++ b/irs-api/src/main/java/net/catenax/irs/aaswrapper/registry/domain/DigitalTwinRegistryClient.java
@@ -9,7 +9,7 @@
 //
 package net.catenax.irs.aaswrapper.registry.domain;
 
-import static net.catenax.irs.configuration.OAuthRestTemplateConfig.OAUTH_REST_TEMPLATE;
+import static net.catenax.irs.configuration.RestTemplateConfig.OAUTH_REST_TEMPLATE;
 
 import java.net.URI;
 

--- a/irs-api/src/main/java/net/catenax/irs/aaswrapper/submodel/domain/SubmodelClient.java
+++ b/irs-api/src/main/java/net/catenax/irs/aaswrapper/submodel/domain/SubmodelClient.java
@@ -9,6 +9,7 @@
 //
 package net.catenax.irs.aaswrapper.submodel.domain;
 
+import static net.catenax.irs.configuration.OAuthRestTemplateConfig.BEARER_REST_TEMPLATE;
 import static net.catenax.irs.configuration.OAuthRestTemplateConfig.OAUTH_REST_TEMPLATE;
 
 import java.net.URI;
@@ -63,7 +64,7 @@ class SubmodelClientImpl implements SubmodelClient {
 
     private final RestTemplate restTemplate;
     private final String aasProxyUrl;
-    /* package */ SubmodelClientImpl(@Qualifier(OAUTH_REST_TEMPLATE) final RestTemplate restTemplate, @Value("${aasProxy.url:}") final String aasProxyUrl) {
+    /* package */ SubmodelClientImpl(@Qualifier(BEARER_REST_TEMPLATE) final RestTemplate restTemplate, @Value("${aasProxy.url:}") final String aasProxyUrl) {
         this.restTemplate = restTemplate;
         this.aasProxyUrl = aasProxyUrl;
     }

--- a/irs-api/src/main/java/net/catenax/irs/aaswrapper/submodel/domain/SubmodelClient.java
+++ b/irs-api/src/main/java/net/catenax/irs/aaswrapper/submodel/domain/SubmodelClient.java
@@ -9,7 +9,7 @@
 //
 package net.catenax.irs.aaswrapper.submodel.domain;
 
-import static net.catenax.irs.configuration.OAuthRestTemplateConfig.BEARER_REST_TEMPLATE;
+import static net.catenax.irs.configuration.OAuthRestTemplateConfig.BASIC_AUTH_REST_TEMPLATE;
 
 import java.net.URI;
 
@@ -63,7 +63,7 @@ class SubmodelClientImpl implements SubmodelClient {
 
     private final RestTemplate restTemplate;
     private final String aasProxyUrl;
-    /* package */ SubmodelClientImpl(@Qualifier(BEARER_REST_TEMPLATE) final RestTemplate restTemplate, @Value("${aasProxy.url:}") final String aasProxyUrl) {
+    /* package */ SubmodelClientImpl(@Qualifier(BASIC_AUTH_REST_TEMPLATE) final RestTemplate restTemplate, @Value("${aasProxy.url:}") final String aasProxyUrl) {
         this.restTemplate = restTemplate;
         this.aasProxyUrl = aasProxyUrl;
     }

--- a/irs-api/src/main/java/net/catenax/irs/aaswrapper/submodel/domain/SubmodelClient.java
+++ b/irs-api/src/main/java/net/catenax/irs/aaswrapper/submodel/domain/SubmodelClient.java
@@ -9,7 +9,7 @@
 //
 package net.catenax.irs.aaswrapper.submodel.domain;
 
-import static net.catenax.irs.configuration.OAuthRestTemplateConfig.BASIC_AUTH_REST_TEMPLATE;
+import static net.catenax.irs.configuration.RestTemplateConfig.BASIC_AUTH_REST_TEMPLATE;
 
 import java.net.URI;
 

--- a/irs-api/src/main/java/net/catenax/irs/aaswrapper/submodel/domain/SubmodelClient.java
+++ b/irs-api/src/main/java/net/catenax/irs/aaswrapper/submodel/domain/SubmodelClient.java
@@ -10,7 +10,6 @@
 package net.catenax.irs.aaswrapper.submodel.domain;
 
 import static net.catenax.irs.configuration.OAuthRestTemplateConfig.BEARER_REST_TEMPLATE;
-import static net.catenax.irs.configuration.OAuthRestTemplateConfig.OAUTH_REST_TEMPLATE;
 
 import java.net.URI;
 

--- a/irs-api/src/main/java/net/catenax/irs/configuration/OAuthRestTemplateConfig.java
+++ b/irs-api/src/main/java/net/catenax/irs/configuration/OAuthRestTemplateConfig.java
@@ -26,6 +26,8 @@ import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.support.BasicAuthenticationInterceptor;
+import org.springframework.http.client.support.BasicAuthorizationInterceptor;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
@@ -45,6 +47,7 @@ import org.springframework.web.client.RestTemplate;
 public class OAuthRestTemplateConfig {
 
     public static final String OAUTH_REST_TEMPLATE = "oAuthRestTemplate";
+    public static final String BEARER_REST_TEMPLATE = "bearerRestTemplate";
 
     private static final String CLIENT_REGISTRATION_ID = "keycloak";
     private static final int TIMEOUT_SECONDS = 30;
@@ -58,6 +61,15 @@ public class OAuthRestTemplateConfig {
 
         return restTemplateBuilder
                 .additionalInterceptors(new OAuthClientCredentialsRestTemplateInterceptor(authorizedClientManager(), clientRegistration))
+                .setReadTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
+                .setConnectTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
+                .build();
+    }
+
+    @Bean(BEARER_REST_TEMPLATE)
+        /* package */ RestTemplate bearerRestTemplate(final RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .additionalInterceptors(new BasicAuthenticationInterceptor("someuser", "somepassword"))
                 .setReadTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
                 .setConnectTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
                 .build();

--- a/irs-api/src/main/java/net/catenax/irs/configuration/OAuthRestTemplateConfig.java
+++ b/irs-api/src/main/java/net/catenax/irs/configuration/OAuthRestTemplateConfig.java
@@ -46,7 +46,7 @@ import org.springframework.web.client.RestTemplate;
 public class OAuthRestTemplateConfig {
 
     public static final String OAUTH_REST_TEMPLATE = "oAuthRestTemplate";
-    public static final String BEARER_REST_TEMPLATE = "bearerRestTemplate";
+    public static final String BASIC_AUTH_REST_TEMPLATE = "basicAuthRestTemplate";
 
     private static final String CLIENT_REGISTRATION_ID = "keycloak";
     private static final int TIMEOUT_SECONDS = 30;
@@ -65,8 +65,8 @@ public class OAuthRestTemplateConfig {
                 .build();
     }
 
-    @Bean(BEARER_REST_TEMPLATE)
-        /* package */ RestTemplate bearerRestTemplate(final RestTemplateBuilder restTemplateBuilder) {
+    @Bean(BASIC_AUTH_REST_TEMPLATE)
+        /* package */ RestTemplate basicAuthRestTemplate(final RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
                 .additionalInterceptors(new BasicAuthenticationInterceptor("someuser", "somepassword"))
                 .setReadTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))

--- a/irs-api/src/main/java/net/catenax/irs/configuration/OAuthRestTemplateConfig.java
+++ b/irs-api/src/main/java/net/catenax/irs/configuration/OAuthRestTemplateConfig.java
@@ -27,7 +27,6 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.support.BasicAuthenticationInterceptor;
-import org.springframework.http.client.support.BasicAuthorizationInterceptor;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;

--- a/irs-api/src/main/java/net/catenax/irs/configuration/RestTemplateConfig.java
+++ b/irs-api/src/main/java/net/catenax/irs/configuration/RestTemplateConfig.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.catenax.irs.annotations.ExcludeFromCodeCoverageGeneratedReport;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,7 +44,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @Configuration
 @RequiredArgsConstructor
-public class OAuthRestTemplateConfig {
+public class RestTemplateConfig {
 
     public static final String OAUTH_REST_TEMPLATE = "oAuthRestTemplate";
     public static final String BASIC_AUTH_REST_TEMPLATE = "basicAuthRestTemplate";
@@ -66,9 +67,10 @@ public class OAuthRestTemplateConfig {
     }
 
     @Bean(BASIC_AUTH_REST_TEMPLATE)
-        /* package */ RestTemplate basicAuthRestTemplate(final RestTemplateBuilder restTemplateBuilder) {
+        /* package */ RestTemplate basicAuthRestTemplate(final RestTemplateBuilder restTemplateBuilder,
+            @Value("${aasProxy.submodel.username}") final String aasProxySubmodelUsername, @Value("${aasProxy.submodel.password}") final String aasProxySubmodelPassword) {
         return restTemplateBuilder
-                .additionalInterceptors(new BasicAuthenticationInterceptor("someuser", "somepassword"))
+                .additionalInterceptors(new BasicAuthenticationInterceptor(aasProxySubmodelUsername, aasProxySubmodelPassword))
                 .setReadTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
                 .setConnectTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
                 .build();

--- a/irs-api/src/main/resources/application.yml
+++ b/irs-api/src/main/resources/application.yml
@@ -95,3 +95,8 @@ resilience4j.retry:
   instances:
     submodelRetryer:
       baseConfig: default
+
+aasProxy:
+  submodel:
+    username: ${AAS_PROXY_SUBMODEL_USERNAME}
+    password: ${AAS_PROXY_SUBMODEL_PASSWORD}

--- a/irs-api/src/main/resources/application.yml
+++ b/irs-api/src/main/resources/application.yml
@@ -98,5 +98,5 @@ resilience4j.retry:
 
 aasProxy:
   submodel:
-    username: ${AAS_PROXY_SUBMODEL_USERNAME}
-    password: ${AAS_PROXY_SUBMODEL_PASSWORD}
+    username: ${AAS_PROXY_SUBMODEL_USERNAME:}
+    password: ${AAS_PROXY_SUBMODEL_PASSWORD:}


### PR DESCRIPTION
I have seen that basic auth is turned off now, so it might be not needed anymore.
But if we want to turn on basic auth on Submodel service, we can merge this PR with temporary interceptor solution.