### PR TITLE
Chore/jdk distro update

### DIFF
--- a/.github/workflows/CI-branches.yml
+++ b/.github/workflows/CI-branches.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonar analysis
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: Cache maven packages

--- a/.github/workflows/CI-branches.yml
+++ b/.github/workflows/CI-branches.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Cache maven packages
         uses: actions/cache@v3

--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Cache maven packages
         uses: actions/cache@v3

--- a/.github/workflows/VeraCode.yml
+++ b/.github/workflows/VeraCode.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.3


### PR DESCRIPTION
- Changed JDK distro from adopt to temurin. Adopt is no longer supported. 
For more information see https://github.com/actions/setup-java#supported-distributions
- Also changed the JDK version of ci-branches.yaml to 17 since main builds on this version already.