### PR TITLE
Adjust AVP paths to new vault secret engine name

### DIFF
--- a/chart/edc-consumer-controlplane/values-int.yaml
+++ b/chart/edc-consumer-controlplane/values-int.yaml
@@ -146,7 +146,7 @@ configuration:
     # edc.vault=
     # edc.vault.certificate=
     edc.vault.clientid=c1778e7d-db16-4404-9080-26d2280d2f63
-    edc.vault.clientsecret=<path:product-traceability-irs/data/int/controlplane#vaultClientSecret>
+    edc.vault.clientsecret=<path:traceability-irs/data/int/controlplane#vaultClientSecret>
     edc.vault.name=cxtsi-dev001-vault
     edc.vault.tenantid=495463c3-0991-4659-9cc5-94b4a3f7b1d6
     # edc.webdid.doh.url=

--- a/chart/edc-consumer-dataplane/values-int.yaml
+++ b/chart/edc-consumer-dataplane/values-int.yaml
@@ -136,7 +136,7 @@ configuration:
     # edc.vault=
     # edc.vault.certificate=
     edc.vault.clientid=c1778e7d-db16-4404-9080-26d2280d2f63
-    edc.vault.clientsecret=<path:product-traceability-irs/data/int/controlplane#vaultClientSecret>
+    edc.vault.clientsecret=<path:traceability-irs/data/int/controlplane#vaultClientSecret>
     edc.vault.name=cxtsi-dev001-vault
     edc.vault.tenantid=495463c3-0991-4659-9cc5-94b4a3f7b1d6
     # edc.webdid.doh.url=

--- a/chart/irs/values-dev.yaml
+++ b/chart/irs/values-dev.yaml
@@ -5,12 +5,12 @@ image:
 
 keycloak:
   oauth2:
-    clientId: <path:product-traceability-irs/data/dev/keycloak/oauth2#clientId>
-    clientSecret: <path:product-traceability-irs/data/dev/keycloak/oauth2#clientSecret>
-    clientTokenUri: <path:product-traceability-irs/data/dev/keycloak/oauth2#tokenUri>
-    jwkSetUri: <path:product-traceability-irs/data/dev/keycloak/oauth2#jwkSetUri>
+    clientId: <path:traceability-irs/data/dev/keycloak/oauth2#clientId>
+    clientSecret: <path:traceability-irs/data/dev/keycloak/oauth2#clientSecret>
+    clientTokenUri: <path:traceability-irs/data/dev/keycloak/oauth2#tokenUri>
+    jwkSetUri: <path:traceability-irs/data/dev/keycloak/oauth2#jwkSetUri>
 
 aasProxy:
   submodel:
-    username: <path:product-traceability-irs/data/dev/aasProxy/submodel#username>
-    password: <path:product-traceability-irs/data/dev/aasProxy/submodel#password>
+    username: <path:traceability-irs/data/dev/aasProxy/submodel#username>
+    password: <path:traceability-irs/data/dev/aasProxy/submodel#password>

--- a/chart/irs/values-int.yaml
+++ b/chart/irs/values-int.yaml
@@ -17,12 +17,12 @@ ingress:
 
 keycloak:
   oauth2:
-    clientId: <path:product-traceability-irs/data/int/keycloak/oauth2#clientId>
-    clientSecret: <path:product-traceability-irs/data/int/keycloak/oauth2#clientSecret>
-    clientTokenUri: <path:product-traceability-irs/data/int/keycloak/oauth2#tokenUri>
-    jwkSetUri: <path:product-traceability-irs/data/int/keycloak/oauth2#jwkSetUri>
+    clientId: <path:traceability-irs/data/int/keycloak/oauth2#clientId>
+    clientSecret: <path:traceability-irs/data/int/keycloak/oauth2#clientSecret>
+    clientTokenUri: <path:traceability-irs/data/int/keycloak/oauth2#tokenUri>
+    jwkSetUri: <path:traceability-irs/data/int/keycloak/oauth2#jwkSetUri>
 
 aasProxy:
   submodel:
-    username: <path:product-traceability-irs/data/int/aasProxy/submodel#username>
-    password: <path:product-traceability-irs/data/int/aasProxy/submodel#password>
+    username: <path:traceability-irs/data/int/aasProxy/submodel#username>
+    password: <path:traceability-irs/data/int/aasProxy/submodel#password>


### PR DESCRIPTION
There was a change in DevSecOps internal naming convention on resources. For IRS this results in a new secret engine name. Before: 'product-traceability-irs' After: 'traceability-irs'.
This PR changes all currently present occurrences of an AVP path that does change due to the new secret engine name.

The secret engine will be migrated with all its contained secrets. The Argo applications wont be affected in the first place, since secrets are already present. If there is a change in the secret values, then a sync and hard refresh of the apps will be necessary.

In case of any troubles, feel free to reach out to me directly.
Cheers,
Sebastian