### PR TITLE
fix(owasp):[-] Added OWASP suppression file to handle false positives

### DIFF
--- a/ci/owasp-suppressions.xml
+++ b/ci/owasp-suppressions.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        Transitive dependency of OkHttp. CVE is only relevant for Gradle builds, not relevant for IRS.
+        ]]></notes>
+        <gav regex="true">org\.jetbrains\.kotlin:.*</gav>
+        <vulnerabilityName>CVE-2022-24329</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        OkHttp vulnerability only relevant for Android platform.
+        ]]></notes>
+        <gav regex="true">com\.squareup\.okhttp3:okhttp.*</gav>
+        <vulnerabilityName>CVE-2021-0341</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        IRS does not expose any HttpInvoker endpoints, CVE not relevant.
+        ]]></notes>
+        <gav regex="true">org\.springframework:spring-web.*</gav>
+        <vulnerabilityName>CVE-2016-1000027</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive, version in use is not affected.
+        ]]></notes>
+        <gav regex="true">org\.springframework\.security:spring-security-crypto.*</gav>
+        <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
+    </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,7 @@
                         <version>${owasp-plugin.version}</version>
                         <configuration>
                             <skip>false</skip>
+                            <suppressionFile>ci/owasp-suppressions.xml</suppressionFile>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
I checked the current OWASP findings and noticed that they don't apply to the IRS (and are not easily muted by updating the libs).
So I created a suppression file to explain and accept those irrelevant findings, so the build can be green again.