### PR TITLE
Fix/tri 543 fix trivy findings

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,6 +40,7 @@ jobs:
           format: "sarif"
           output: "trivy-results1.sarif"
           severity: "CRITICAL,HIGH"
+          skip-dirs: "chart/aasregistry,chart/edc-controlplane,chart/edc-dataplane,chart/edc-provider-control-plane,chart/edc-provider-data-plane,chart/submodelservers"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.m2 mvn -B clean package -pl :$BUILD_TARGET 
 
 
 # Copy the jar and build image
-FROM eclipse-temurin:18-jre AS irs-api
+FROM eclipse-temurin:18-jre-alpine AS irs-api
 
 ARG UID=10000
 ARG GID=1000

--- a/chart/edc-consumer-dataplane/values.yaml
+++ b/chart/edc-consumer-dataplane/values.yaml
@@ -55,7 +55,8 @@ securityContext:
   # -- Requires the container to run without root privileges
   runAsNonRoot: true
   # -- The container's process will run with the specified uid
-  runAsUser: 10000
+  runAsUser: 10001
+  runAsGroup: 10001
 
 livenessProbe:
   # -- Whether to enable kubernetes [liveness-probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)

--- a/chart/grafana/templates/configmap.yaml
+++ b/chart/grafana/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "grafana.fullname" . }}-configmap
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 data:

--- a/chart/grafana/templates/deployment.yaml
+++ b/chart/grafana/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
           volumeMounts:
             - name: {{ include "grafana.fullname" . }}-config
               mountPath: /etc/grafana/provisioning/datasources
+            - name: {{ include "grafana.fullname" . }}-filesystem
+              mountPath: /var/lib/grafana
           ports:
             - name: http
               containerPort: 3000
@@ -81,6 +83,8 @@ spec:
         - name: {{ include "grafana.fullname" . }}-config
           configMap:
             name: {{ include "grafana.fullname" . }}-configmap
+        - name: {{ include "grafana.fullname" . }}-filesystem
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/grafana/templates/hpa.yaml
+++ b/chart/grafana/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "grafana.fullname" . }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 spec:

--- a/chart/grafana/templates/serviceaccount.yaml
+++ b/chart/grafana/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "grafana.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/chart/grafana/values.yaml
+++ b/chart/grafana/values.yaml
@@ -27,16 +27,24 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# -- The [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) defines privilege and access control settings for a Pod within the deployment
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
 # Following Catena-X Helm Best Practices @url: https://catenax-ng.github.io/docs/kubernetes-basics/helm
-# @url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+# The [container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) defines privilege and access control settings for a Container within a pod
 securityContext:
   allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  # -- Requires the container to run without root privileges
   runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 3000
+  # -- The container's process will run with the specified uid
+  runAsUser: 10001
+  runAsGroup: 10001
 
 service:
   type: ClusterIP
@@ -60,17 +68,18 @@ ingress:
       # Default secret for certificate creation already provided to your namespace
       secretName: tls-secret
 
-resources: {}
+# -- [Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) applied to the deployed pod
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 1.5
+    memory: 1.5Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
 
 autoscaling:
   enabled: false

--- a/chart/prometheus/templates/configmap.yaml
+++ b/chart/prometheus/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "prometheus.fullname" . }}-configmap
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "prometheus.labels" . | nindent 4 }}
 data:

--- a/chart/prometheus/templates/deployment.yaml
+++ b/chart/prometheus/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "prometheus.fullname" . }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "prometheus.labels" . | nindent 4 }}
 spec:

--- a/chart/prometheus/templates/hpa.yaml
+++ b/chart/prometheus/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "prometheus.fullname" . }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "prometheus.labels" . | nindent 4 }}
 spec:

--- a/chart/prometheus/templates/ingress.yaml
+++ b/chart/prometheus/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "prometheus.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/chart/prometheus/templates/service.yaml
+++ b/chart/prometheus/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "prometheus.fullname" . }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "prometheus.labels" . | nindent 4 }}
 spec:

--- a/chart/prometheus/templates/serviceaccount.yaml
+++ b/chart/prometheus/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "prometheus.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "prometheus.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/chart/prometheus/values.yaml
+++ b/chart/prometheus/values.yaml
@@ -27,16 +27,24 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  #fsGroup: nobody
+# -- The [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) defines privilege and access control settings for a Pod within the deployment
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
 # Following Catena-X Helm Best Practices @url: https://catenax-ng.github.io/docs/kubernetes-basics/helm
-# @url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+# The [container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) defines privilege and access control settings for a Container within a pod
 securityContext:
   allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  # -- Requires the container to run without root privileges
   runAsNonRoot: true
+  # -- The container's process will run with the specified uid
   runAsUser: 65534
-  #runAsGroup: nobody
+  runAsGroup: 10001
 
 service:
   type: ClusterIP
@@ -58,17 +66,18 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
+# -- [Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) applied to the deployed pod
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 1.5
+    memory: 1.5Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
https://jira.catena-x.net/browse/TRI-543
- Change Docker build image to "eclipse-temurin:18-jre-alpine"
- Add configuration for securityContext, podSecurityContext and resources to grafana and prometheus helm charts
- Add volume mount for grafana after change to read only root file system
- Add missing namespaces to templates
- Exclude dev-setup helm charts from trivy scan

I tested the configuration on DEV and it works fine.