### PR TITLE
feat(ref):[TRI-XXX] - move Digital Twin Registry api client

### DIFF
--- a/irs-api/src/main/java/net/catenax/irs/aaswrapper/job/AASHandler.java
+++ b/irs-api/src/main/java/net/catenax/irs/aaswrapper/job/AASHandler.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import io.github.resilience4j.retry.RetryRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.catenax.irs.aaswrapper.registry.domain.DigitalTwinRegistryFacade;
+import net.catenax.irs.twinregistry.DigitalTwinRegistryFacade;
 import net.catenax.irs.aaswrapper.submodel.domain.SubmodelFacade;
 import net.catenax.irs.bpdm.BpdmFacade;
 import net.catenax.irs.component.Bpn;

--- a/irs-api/src/main/java/net/catenax/irs/configuration/JobConfiguration.java
+++ b/irs-api/src/main/java/net/catenax/irs/configuration/JobConfiguration.java
@@ -20,7 +20,7 @@ import net.catenax.irs.aaswrapper.job.AASTransferProcessManager;
 import net.catenax.irs.aaswrapper.job.ItemDataRequest;
 import net.catenax.irs.aaswrapper.job.ItemTreesAssembler;
 import net.catenax.irs.aaswrapper.job.TreeRecursiveLogic;
-import net.catenax.irs.aaswrapper.registry.domain.DigitalTwinRegistryFacade;
+import net.catenax.irs.twinregistry.DigitalTwinRegistryFacade;
 import net.catenax.irs.aaswrapper.submodel.domain.SubmodelFacade;
 import net.catenax.irs.bpdm.BpdmFacade;
 import net.catenax.irs.connector.job.JobOrchestrator;

--- a/irs-api/src/main/java/net/catenax/irs/twinregistry/AssetAdministrationShellTestdataCreator.java
+++ b/irs-api/src/main/java/net/catenax/irs/twinregistry/AssetAdministrationShellTestdataCreator.java
@@ -8,7 +8,7 @@
 // additional information regarding license terms.
 //
 //
-package net.catenax.irs.aaswrapper.registry.domain;
+package net.catenax.irs.twinregistry;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/irs-api/src/main/java/net/catenax/irs/twinregistry/DigitalTwinRegistryClient.java
+++ b/irs-api/src/main/java/net/catenax/irs/twinregistry/DigitalTwinRegistryClient.java
@@ -7,7 +7,7 @@
 // See the LICENSE file(s) distributed with this work for
 // additional information regarding license terms.
 //
-package net.catenax.irs.aaswrapper.registry.domain;
+package net.catenax.irs.twinregistry;
 
 import static net.catenax.irs.configuration.RestTemplateConfig.OAUTH_REST_TEMPLATE;
 

--- a/irs-api/src/main/java/net/catenax/irs/twinregistry/DigitalTwinRegistryFacade.java
+++ b/irs-api/src/main/java/net/catenax/irs/twinregistry/DigitalTwinRegistryFacade.java
@@ -7,7 +7,7 @@
 // See the LICENSE file(s) distributed with this work for
 // additional information regarding license terms.
 //
-package net.catenax.irs.aaswrapper.registry.domain;
+package net.catenax.irs.twinregistry;
 
 import java.util.Collections;
 import java.util.List;

--- a/irs-api/src/test/java/net/catenax/irs/aaswrapper/job/AASTransferProcessManagerTest.java
+++ b/irs-api/src/test/java/net/catenax/irs/aaswrapper/job/AASTransferProcessManagerTest.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
 import net.catenax.irs.InMemoryBlobStore;
-import net.catenax.irs.aaswrapper.registry.domain.DigitalTwinRegistryFacade;
+import net.catenax.irs.twinregistry.DigitalTwinRegistryFacade;
 import net.catenax.irs.aaswrapper.submodel.domain.SubmodelFacade;
 import net.catenax.irs.bpdm.BpdmFacade;
 import net.catenax.irs.connector.job.ResponseStatus;

--- a/irs-api/src/test/java/net/catenax/irs/twinregistry/AssetAdministrationShellTestdataCreatorTest.java
+++ b/irs-api/src/test/java/net/catenax/irs/twinregistry/AssetAdministrationShellTestdataCreatorTest.java
@@ -8,7 +8,7 @@
  * additional information regarding license terms.
  *
  */
-package net.catenax.irs.aaswrapper.registry.domain;
+package net.catenax.irs.twinregistry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/irs-api/src/test/java/net/catenax/irs/twinregistry/DigitalTwinRegistryClientImplTest.java
+++ b/irs-api/src/test/java/net/catenax/irs/twinregistry/DigitalTwinRegistryClientImplTest.java
@@ -1,4 +1,4 @@
-package net.catenax.irs.aaswrapper.registry.domain;
+package net.catenax.irs.twinregistry;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/irs-api/src/test/java/net/catenax/irs/twinregistry/DigitalTwinRegistryExponentialRetryTest.java
+++ b/irs-api/src/test/java/net/catenax/irs/twinregistry/DigitalTwinRegistryExponentialRetryTest.java
@@ -1,4 +1,4 @@
-package net.catenax.irs.aaswrapper.registry.domain;
+package net.catenax.irs.twinregistry;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/irs-api/src/test/java/net/catenax/irs/twinregistry/DigitalTwinRegistryFacadeTest.java
+++ b/irs-api/src/test/java/net/catenax/irs/twinregistry/DigitalTwinRegistryFacadeTest.java
@@ -1,13 +1,11 @@
-package net.catenax.irs.aaswrapper.registry.domain;
+package net.catenax.irs.twinregistry;
 
 import static net.catenax.irs.util.TestMother.jobParameter;
 import static net.catenax.irs.util.TestMother.jobParameterEmptyFilter;
 import static net.catenax.irs.util.TestMother.jobParameterFilter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Previously we thought that call to Twin Registry service will be done through AASWrapper.
Right now we are calling service directly, so I moved rest client outside aaswrapper package.