### PR TITLE
Exclude codeql rule "Unused classes and interfaces"

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "IRS CodeQL config"
+
+# Exclude "Unused classes and interfaces"
+query-filters:
+  - exclude:
+      id: java/unused-reference-type

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,8 @@ jobs:
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
           # The queries security-extended and security-and-quality are built into CodeQL.
-          queries: security-extended, security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
+          queries: +security-and-quality,security-extended
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
False positive because necessary test classes are detected as unused - statement from @ds-jkreutzfeld 