### PR TITLE
Feature/tri 611 testdata set 1.3.2

### DIFF
--- a/.github/workflows/TEST-INT-Setup-Data.yml
+++ b/.github/workflows/TEST-INT-Setup-Data.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           python testdata-transform/reset-env.py \
           -a $AAS_URL \
-          -e1 EDC_URL_1 \
-          -e2 EDC_URL_2 \
-          -e3 EDC_URL_3 \
+          -e1 $EDC_URL_1 \
+          -e2 $EDC_URL_2 \
+          -e3 $EDC_URL_3 \
           -k $EDC_API_KEY
           python testdata-transform/transform-and-upload.py \
           -f $TESTFILE_PATH \
@@ -83,8 +83,8 @@ jobs:
           -s2 $SUBMODEL_URL_2 \
           -s3 $SUBMODEL_URL_3 \
           -a $AAS_URL \
-          -e1 EDC_URL_1 \
-          -e2 EDC_URL_2 \
-          -e3 EDC_URL_3 \
+          -e1 $EDC_URL_1 \
+          -e2 $EDC_URL_2 \
+          -e3 $EDC_URL_3 \
           -k $EDC_API_KEY \
           -e $ESR_URL

--- a/.github/workflows/TEST-INT-Setup-Data.yml
+++ b/.github/workflows/TEST-INT-Setup-Data.yml
@@ -35,6 +35,10 @@ on:
         description: 'API-Key for the provider control plane'
         required: true
         type: string
+      esrUrl:
+        description: 'ESR Url'
+        required: false
+        type: string
 
 
 jobs:
@@ -60,6 +64,7 @@ jobs:
           AAS_URL: ${{ github.event.inputs.aasUrl }}
           EDC_URL: ${{ github.event.inputs.edcUrl }}
           EDC_API_KEY: ${{ github.event.inputs.edcApiKey }}
+          ESR_URL: ${{ github.event.inputs.esrUrl }}
         run: |
           python testdata-transform/reset-env.py \
           -a $AAS_URL \
@@ -73,4 +78,5 @@ jobs:
           -c $INTERNAL_PROVIDER_CONTROL_PLANE \
           -a $AAS_URL \
           -e $EDC_URL \
-          -k $EDC_API_KEY
+          -k $EDC_API_KEY \
+          -E $ESR_URL

--- a/.github/workflows/TEST-INT-Setup-Data.yml
+++ b/.github/workflows/TEST-INT-Setup-Data.yml
@@ -19,16 +19,20 @@ on:
         description: 'URL for Submodel server 3'
         required: true
         type: string
-      publicProviderControlPlane:
-        description: 'Public provider control plane URL of ids'
-        required: true
-        type: string
       aasUrl:
         description: 'Digital twin registry URL'
         required: true
         type: string
-      edcUrl:
-        description: 'Provider control plane URL'
+      edcUrl1:
+        description: 'Provider 1 control plane URL'
+        required: true
+        type: string
+      edcUrl2:
+        description: 'Provider 2 control plane URL'
+        required: true
+        type: string
+      edcUrl3:
+        description: 'Provider 3 control plane URL'
         required: true
         type: string
       edcApiKey:
@@ -36,7 +40,7 @@ on:
         required: true
         type: string
       esrUrl:
-        description: 'ESR Url'
+        description: 'ESR endpoint Url'
         required: false
         type: string
 
@@ -60,23 +64,27 @@ jobs:
           SUBMODEL_URL_1: ${{ github.event.inputs.submodelUrl1 }}
           SUBMODEL_URL_2: ${{ github.event.inputs.submodelUrl2 }}
           SUBMODEL_URL_3: ${{ github.event.inputs.submodelUrl3 }}
-          INTERNAL_PROVIDER_CONTROL_PLANE: ${{ github.event.inputs.publicProviderControlPlane }}
           AAS_URL: ${{ github.event.inputs.aasUrl }}
-          EDC_URL: ${{ github.event.inputs.edcUrl }}
+          EDC_URL_1: ${{ github.event.inputs.edcUrl1 }}
+          EDC_URL_2: ${{ github.event.inputs.edcUrl2 }}
+          EDC_URL_3: ${{ github.event.inputs.edcUrl3 }}
           EDC_API_KEY: ${{ github.event.inputs.edcApiKey }}
           ESR_URL: ${{ github.event.inputs.esrUrl }}
         run: |
           python testdata-transform/reset-env.py \
           -a $AAS_URL \
-          -e $EDC_URL \
+          -e1 EDC_URL_1 \
+          -e2 EDC_URL_2 \
+          -e3 EDC_URL_3 \
           -k $EDC_API_KEY
           python testdata-transform/transform-and-upload.py \
           -f $TESTFILE_PATH \
           -s1 $SUBMODEL_URL_1 \
           -s2 $SUBMODEL_URL_2 \
           -s3 $SUBMODEL_URL_3 \
-          -c $INTERNAL_PROVIDER_CONTROL_PLANE \
           -a $AAS_URL \
-          -e $EDC_URL \
+          -e1 EDC_URL_1 \
+          -e2 EDC_URL_2 \
+          -e3 EDC_URL_3 \
           -k $EDC_API_KEY \
-          -E $ESR_URL
+          -e $ESR_URL

--- a/.github/workflows/TEST-INT-Setup-Data.yml
+++ b/.github/workflows/TEST-INT-Setup-Data.yml
@@ -86,5 +86,4 @@ jobs:
           -e1 $EDC_URL_1 \
           -e2 $EDC_URL_2 \
           -e3 $EDC_URL_3 \
-          -k $EDC_API_KEY \
-          -e $ESR_URL
+          -k $EDC_API_KEY 

--- a/charts/irs/charts/edc-controlplane/values-dev-provider.yaml
+++ b/charts/irs/charts/edc-controlplane/values-dev-provider.yaml
@@ -38,6 +38,11 @@ ingresses:
       # -- If preset enables certificate generation via cert-manager cluster-wide issuer
       clusterIssuer: ""
 
+resources:
+  limits:
+    cpu: 1.5
+    memory: 2Gi
+
 configuration:
   # -- EDC configuration.properties configuring aspects of the [eclipse-dataspaceconnector](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector)
   properties: |-

--- a/charts/irs/charts/edc-controlplane/values-dev-provider2.yaml
+++ b/charts/irs/charts/edc-controlplane/values-dev-provider2.yaml
@@ -1,0 +1,101 @@
+---
+# Default values for edc-controlplane.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Overrides the charts name
+nameOverride: "irs-provider-controlplane2"
+# -- Overrides the releases full name
+fullnameOverride: "irs-provider-controlplane2"
+
+## Ingress declaration to expose the network service.
+ingresses:
+  ## Public / Internet facing Ingress
+  - enabled: true
+    # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+    hostname: "irs-provider-controlplane2.dev.demo.catena-x.net"
+    # -- Additional ingress annotations to add
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: HTTP
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+    # -- EDC endpoints exposed by this ingress resource
+    endpoints:
+      - ids
+      - data
+    # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+    className: "nginx"
+    # -- Enables TLS on the ingress resource
+    tls:
+      - hosts:
+          - "irs-provider-controlplane2.dev.demo.catena-x.net"
+        # Default secret for certificate creation already provided to your namespace
+        secretName: tls-secret
+    ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+    certManager:
+      # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+      issuer: ""
+      # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+      clusterIssuer: ""
+
+configuration:
+  # -- EDC configuration.properties configuring aspects of the [eclipse-dataspaceconnector](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector)
+  properties: |-
+    edc.api.auth.key=123456
+    
+    ids.webhook.address=https://irs-provider-controlplane2.dev.demo.catena-x.net
+    
+    edc.ids.id=urn:connector:edc-provider-controlplane
+    edc.ids.catalog.id=urn:catalog:default
+    edc.ids.endpoint=https://irs-provider-controlplane2.dev.demo.catena-x.net/api/v1/ids
+    edc.ids.endpoint.audience=https://irs-provider-controlplane2.dev.demo.catena-x.net/api/v1/ids/data
+    
+    edc.receiver.http.endpoint=http://irs-provider-controlplane2:8080/api/service/pull
+    
+    edc.transfer.proxy.endpoint=http://irs-provider-dataplane2:8185/api/public
+    edc.transfer.proxy.token.signer.privatekey.alias=irs-dev-daps-cert-provider-key
+    edc.transfer.proxy.token.verifier.publickey.alias=irs-dev-daps-cert-provider
+    
+    edc.dataplane.selector.provider2.url=http://irs-provider-dataplane2:9999/api/dataplane/control
+    edc.dataplane.selector.provider2.sourcetypes=HttpData
+    edc.dataplane.selector.provider2.destinationtypes=HttpProxy
+    edc.dataplane.selector.provider2.properties={ "publicApiUrl": "http://irs-provider-dataplane2:8185/api/public" }
+    
+    edc.oauth.client.id=B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A:keyid:B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A
+    edc.oauth.private.key.alias=irs-dev-daps-cert-provider-key
+    edc.oauth.provider.audience=idsc:IDS_CONNECTORS_ALL
+    edc.oauth.provider.jwks.url=https://daps-irs.dev.demo.catena-x.net/.well-known/jwks.json
+    edc.oauth.public.key.alias=irs-dev-daps-cert-provider
+    edc.oauth.token.url=https://daps-irs.dev.demo.catena-x.net/token
+    
+    edc.vault.hashicorp.url=https://vault.demo.catena-x.net
+    edc.vault.hashicorp.token=<path:traceability-irs/data/dev/controlplane#vaultToken>
+    edc.vault.hashicorp.timeout.seconds=30
+    edc.vault.hashicorp.health.check.enabled=true
+    edc.vault.hashicorp.health.check.standby.ok=true
+    edc.vault.hashicorp.api.secret.path=/v1/traceability-irs
+    
+    edc.data.encryption.keys.alias=irs-dev-daps-cert-consumer-key
+    edc.data.encryption.algorithm=NONE
+
+    # Postgresql related configuration
+    edc.datasource.asset.name=asset
+    edc.datasource.asset.url=jdbc:postgresql://irs-edc-postgres2-postgresql-hl:5432/edc
+    edc.datasource.asset.user=edc
+    edc.datasource.asset.password=databasepassword
+    edc.datasource.contractdefinition.name=contractdefinition
+    edc.datasource.contractdefinition.url=jdbc:postgresql://irs-edc-postgres2-postgresql-hl:5432/edc
+    edc.datasource.contractdefinition.user=edc
+    edc.datasource.contractdefinition.password=databasepassword
+    edc.datasource.contractnegotiation.name=contractnegotiation
+    edc.datasource.contractnegotiation.url=jdbc:postgresql://irs-edc-postgres2-postgresql-hl:5432/edc
+    edc.datasource.contractnegotiation.user=edc
+    edc.datasource.contractnegotiation.password=databasepassword
+    edc.datasource.policy.name=policy
+    edc.datasource.policy.url=jdbc:postgresql://irs-edc-postgres2-postgresql-hl:5432/edc
+    edc.datasource.policy.user=edc
+    edc.datasource.policy.password=databasepassword
+    edc.datasource.transferprocess.name=transferprocess
+    edc.datasource.transferprocess.url=jdbc:postgresql://irs-edc-postgres2-postgresql-hl:5432/edc
+    edc.datasource.transferprocess.user=edc
+    edc.datasource.transferprocess.password=databasepassword

--- a/charts/irs/charts/edc-controlplane/values-dev-provider2.yaml
+++ b/charts/irs/charts/edc-controlplane/values-dev-provider2.yaml
@@ -38,6 +38,11 @@ ingresses:
       # -- If preset enables certificate generation via cert-manager cluster-wide issuer
       clusterIssuer: ""
 
+resources:
+  limits:
+    cpu: 1.5
+    memory: 2Gi
+
 configuration:
   # -- EDC configuration.properties configuring aspects of the [eclipse-dataspaceconnector](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector)
   properties: |-

--- a/charts/irs/charts/edc-controlplane/values-dev-provider3.yaml
+++ b/charts/irs/charts/edc-controlplane/values-dev-provider3.yaml
@@ -1,0 +1,101 @@
+---
+# Default values for edc-controlplane.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Overrides the charts name
+nameOverride: "irs-provider-controlplane3"
+# -- Overrides the releases full name
+fullnameOverride: "irs-provider-controlplane3"
+
+## Ingress declaration to expose the network service.
+ingresses:
+  ## Public / Internet facing Ingress
+  - enabled: true
+    # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+    hostname: "irs-provider-controlplane3.dev.demo.catena-x.net"
+    # -- Additional ingress annotations to add
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: HTTP
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+    # -- EDC endpoints exposed by this ingress resource
+    endpoints:
+      - ids
+      - data
+    # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+    className: "nginx"
+    # -- Enables TLS on the ingress resource
+    tls:
+      - hosts:
+          - "irs-provider-controlplane3.dev.demo.catena-x.net"
+        # Default secret for certificate creation already provided to your namespace
+        secretName: tls-secret
+    ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+    certManager:
+      # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+      issuer: ""
+      # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+      clusterIssuer: ""
+
+configuration:
+  # -- EDC configuration.properties configuring aspects of the [eclipse-dataspaceconnector](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector)
+  properties: |-
+    edc.api.auth.key=123456
+    
+    ids.webhook.address=https://irs-provider-controlplane3.dev.demo.catena-x.net
+    
+    edc.ids.id=urn:connector:edc-provider-controlplane
+    edc.ids.catalog.id=urn:catalog:default
+    edc.ids.endpoint=https://irs-provider-controlplane3.dev.demo.catena-x.net/api/v1/ids
+    edc.ids.endpoint.audience=https://irs-provider-controlplane3.dev.demo.catena-x.net/api/v1/ids/data
+    
+    edc.receiver.http.endpoint=http://irs-provider-controlplane3:8080/api/service/pull
+    
+    edc.transfer.proxy.endpoint=http://irs-provider-dataplane3:8185/api/public
+    edc.transfer.proxy.token.signer.privatekey.alias=irs-dev-daps-cert-provider-key
+    edc.transfer.proxy.token.verifier.publickey.alias=irs-dev-daps-cert-provider
+    
+    edc.dataplane.selector.provider.url=http://irs-provider-dataplane3:9999/api/dataplane/control
+    edc.dataplane.selector.provider.sourcetypes=HttpData
+    edc.dataplane.selector.provider.destinationtypes=HttpProxy
+    edc.dataplane.selector.provider.properties={ "publicApiUrl": "http://irs-provider-dataplane3:8185/api/public" }
+    
+    edc.oauth.client.id=B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A:keyid:B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A
+    edc.oauth.private.key.alias=irs-dev-daps-cert-provider-key
+    edc.oauth.provider.audience=idsc:IDS_CONNECTORS_ALL
+    edc.oauth.provider.jwks.url=https://daps-irs.dev.demo.catena-x.net/.well-known/jwks.json
+    edc.oauth.public.key.alias=irs-dev-daps-cert-provider
+    edc.oauth.token.url=https://daps-irs.dev.demo.catena-x.net/token
+    
+    edc.vault.hashicorp.url=https://vault.demo.catena-x.net
+    edc.vault.hashicorp.token=<path:traceability-irs/data/dev/controlplane#vaultToken>
+    edc.vault.hashicorp.timeout.seconds=30
+    edc.vault.hashicorp.health.check.enabled=true
+    edc.vault.hashicorp.health.check.standby.ok=true
+    edc.vault.hashicorp.api.secret.path=/v1/traceability-irs
+    
+    edc.data.encryption.keys.alias=irs-dev-daps-cert-consumer-key
+    edc.data.encryption.algorithm=NONE
+
+    # Postgresql related configuration
+    edc.datasource.asset.name=asset
+    edc.datasource.asset.url=jdbc:postgresql://irs-edc-postgres3-postgresql-hl:5432/edc
+    edc.datasource.asset.user=edc
+    edc.datasource.asset.password=databasepassword
+    edc.datasource.contractdefinition.name=contractdefinition
+    edc.datasource.contractdefinition.url=jdbc:postgresql://irs-edc-postgres3-postgresql-hl:5432/edc
+    edc.datasource.contractdefinition.user=edc
+    edc.datasource.contractdefinition.password=databasepassword
+    edc.datasource.contractnegotiation.name=contractnegotiation
+    edc.datasource.contractnegotiation.url=jdbc:postgresql://irs-edc-postgres3-postgresql-hl:5432/edc
+    edc.datasource.contractnegotiation.user=edc
+    edc.datasource.contractnegotiation.password=databasepassword
+    edc.datasource.policy.name=policy
+    edc.datasource.policy.url=jdbc:postgresql://irs-edc-postgres3-postgresql-hl:5432/edc
+    edc.datasource.policy.user=edc
+    edc.datasource.policy.password=databasepassword
+    edc.datasource.transferprocess.name=transferprocess
+    edc.datasource.transferprocess.url=jdbc:postgresql://irs-edc-postgres3-postgresql-hl:5432/edc
+    edc.datasource.transferprocess.user=edc
+    edc.datasource.transferprocess.password=databasepassword

--- a/charts/irs/charts/edc-controlplane/values-dev-provider3.yaml
+++ b/charts/irs/charts/edc-controlplane/values-dev-provider3.yaml
@@ -61,10 +61,10 @@ configuration:
     edc.transfer.proxy.token.signer.privatekey.alias=irs-dev-daps-cert-provider-key
     edc.transfer.proxy.token.verifier.publickey.alias=irs-dev-daps-cert-provider
     
-    edc.dataplane.selector.provider.url=http://irs-provider-dataplane3:9999/api/dataplane/control
-    edc.dataplane.selector.provider.sourcetypes=HttpData
-    edc.dataplane.selector.provider.destinationtypes=HttpProxy
-    edc.dataplane.selector.provider.properties={ "publicApiUrl": "http://irs-provider-dataplane3:8185/api/public" }
+    edc.dataplane.selector.provider3.url=http://irs-provider-dataplane3:9999/api/dataplane/control
+    edc.dataplane.selector.provider3.sourcetypes=HttpData
+    edc.dataplane.selector.provider3.destinationtypes=HttpProxy
+    edc.dataplane.selector.provider3.properties={ "publicApiUrl": "http://irs-provider-dataplane3:8185/api/public" }
     
     edc.oauth.client.id=B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A:keyid:B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A
     edc.oauth.private.key.alias=irs-dev-daps-cert-provider-key

--- a/charts/irs/charts/edc-controlplane/values-dev-provider3.yaml
+++ b/charts/irs/charts/edc-controlplane/values-dev-provider3.yaml
@@ -38,6 +38,11 @@ ingresses:
       # -- If preset enables certificate generation via cert-manager cluster-wide issuer
       clusterIssuer: ""
 
+resources:
+  limits:
+    cpu: 1.5
+    memory: 2Gi
+
 configuration:
   # -- EDC configuration.properties configuring aspects of the [eclipse-dataspaceconnector](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector)
   properties: |-

--- a/charts/irs/charts/edc-dataplane/values-dev-provider2.yaml
+++ b/charts/irs/charts/edc-dataplane/values-dev-provider2.yaml
@@ -1,0 +1,59 @@
+---
+# Default values for edc-dataplane.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Overrides the charts name
+nameOverride: "irs-provider-dataplane2"
+# -- Overrides the releases full name
+fullnameOverride: "irs-provider-dataplane2"
+
+## Ingress declaration to expose the network service.
+ingresses:
+  ## Public / Internet facing Ingress
+  - enabled: true
+    # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+    hostname: "irs-provider-dataplane2.dev.demo.catena-x.net"
+    # -- Additional ingress annotations to add
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    # -- EDC endpoints exposed by this ingress resource
+    endpoints:
+      - public
+    # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+    className: "nginx"
+    # -- Enables TLS on the ingress resource
+    tls:
+      - hosts:
+          - "irs-provider-dataplane2.dev.demo.catena-x.net"
+        # Default secret for certificate creation already provided to your namespace
+        secretName: tls-secret
+    ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+    certManager:
+      # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+      issuer: ""
+      # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+      clusterIssuer: ""
+
+configuration:
+  # -- EDC configuration.properties configuring aspects of the [eclipse-dataspaceconnector](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector)
+  properties: |-
+    edc.api.auth.key=123456
+    
+    edc.dataplane.token.validation.endpoint=http://irs-provider-controlplane2:8182/validation/token
+    
+    edc.oauth.client.id=B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A:keyid:B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A
+    edc.oauth.private.key.alias=irs-dev-daps-cert-provider-key
+    edc.oauth.provider.audience=idsc:IDS_CONNECTORS_ALL
+    edc.oauth.provider.jwks.url=https://daps-irs.dev.demo.catena-x.net/.well-known/jwks.json
+    edc.oauth.public.key.alias=irs-dev-daps-cert-provider
+    edc.oauth.token.url=https://daps-irs.dev.demo.catena-x.net/token
+    
+    edc.vault.hashicorp.url=https://vault.demo.catena-x.net
+    edc.vault.hashicorp.token=<path:traceability-irs/data/dev/controlplane#vaultToken>
+    edc.vault.hashicorp.timeout.seconds=30
+    edc.vault.hashicorp.health.check.enabled=true
+    edc.vault.hashicorp.health.check.standby.ok=true
+    edc.vault.hashicorp.api.secret.path=/v1/traceability-irs

--- a/charts/irs/charts/edc-dataplane/values-dev-provider3.yaml
+++ b/charts/irs/charts/edc-dataplane/values-dev-provider3.yaml
@@ -1,0 +1,59 @@
+---
+# Default values for edc-dataplane.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Overrides the charts name
+nameOverride: "irs-provider-dataplane3"
+# -- Overrides the releases full name
+fullnameOverride: "irs-provider-dataplane3"
+
+## Ingress declaration to expose the network service.
+ingresses:
+  ## Public / Internet facing Ingress
+  - enabled: true
+    # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+    hostname: "irs-provider-dataplane3.dev.demo.catena-x.net"
+    # -- Additional ingress annotations to add
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    # -- EDC endpoints exposed by this ingress resource
+    endpoints:
+      - public
+    # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+    className: "nginx"
+    # -- Enables TLS on the ingress resource
+    tls:
+      - hosts:
+          - "irs-provider-dataplane3.dev.demo.catena-x.net"
+        # Default secret for certificate creation already provided to your namespace
+        secretName: tls-secret
+    ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+    certManager:
+      # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+      issuer: ""
+      # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+      clusterIssuer: ""
+
+configuration:
+  # -- EDC configuration.properties configuring aspects of the [eclipse-dataspaceconnector](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector)
+  properties: |-
+    edc.api.auth.key=123456
+    
+    edc.dataplane.token.validation.endpoint=http://irs-provider-controlplane3:8182/validation/token
+    
+    edc.oauth.client.id=B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A:keyid:B9:7B:1A:54:74:DC:C7:45:6E:A2:24:DC:3F:6D:A7:4A:DD:D2:26:6A
+    edc.oauth.private.key.alias=irs-dev-daps-cert-provider-key
+    edc.oauth.provider.audience=idsc:IDS_CONNECTORS_ALL
+    edc.oauth.provider.jwks.url=https://daps-irs.dev.demo.catena-x.net/.well-known/jwks.json
+    edc.oauth.public.key.alias=irs-dev-daps-cert-provider
+    edc.oauth.token.url=https://daps-irs.dev.demo.catena-x.net/token
+    
+    edc.vault.hashicorp.url=https://vault.demo.catena-x.net
+    edc.vault.hashicorp.token=<path:traceability-irs/data/dev/controlplane#vaultToken>
+    edc.vault.hashicorp.timeout.seconds=30
+    edc.vault.hashicorp.health.check.enabled=true
+    edc.vault.hashicorp.health.check.standby.ok=true
+    edc.vault.hashicorp.api.secret.path=/v1/traceability-irs

--- a/charts/irs/charts/edc-postgresql/values-dev.yaml
+++ b/charts/irs/charts/edc-postgresql/values-dev.yaml
@@ -3,3 +3,9 @@ auth:
   username: <path:traceability-irs/data/dev/controlplane#databaseuser>
   password: <path:traceability-irs/data/dev/controlplane#databasepassword>
   database: "edc"
+
+primary:
+  resources:
+    limits:
+      cpu: 1.5
+      memory: 1.5Gi

--- a/charts/irs/values-dev.yaml
+++ b/charts/irs/values-dev.yaml
@@ -76,6 +76,7 @@ irs-aaswrapper:
       wrapper.consumer.edc.apikey.name=X-Api-Key
       wrapper.consumer.edc.apikey.value=123456
       wrapper.callback.timeout=60
+      wrapper.cache.enabled=true
       # wrapper.auth.basic.someuser=somepassword
 
 # Values for grafana subchart.

--- a/charts/irs/values-esr.yaml
+++ b/charts/irs/values-esr.yaml
@@ -34,7 +34,7 @@ rootUser: <path:traceability-irs/data/dev/minio#minioUser>
 rootPassword: <path:traceability-irs/data/dev/minio#minioPassword>
 
 digitalTwinRegistry:
-  url: https://irs-aas-registry.dev.demo.catena-x.net
+  url: https://irs-aas-registry-esr.dev.demo.catena-x.net
 
 global:
   enablePrometheus: false
@@ -76,6 +76,7 @@ irs-aaswrapper:
       wrapper.consumer.edc.apikey.name=X-Api-Key
       wrapper.consumer.edc.apikey.value=123456
       wrapper.callback.timeout=60
+      wrapper.cache.enabled=true
       # wrapper.auth.basic.someuser=somepassword
 
 # Values for minio subchart.

--- a/charts/irs/values-int.yaml
+++ b/charts/irs/values-int.yaml
@@ -53,6 +53,7 @@ irs-aaswrapper:
       wrapper.consumer.edc.apikey.name=X-Api-Key
       wrapper.consumer.edc.apikey.value=123456
       wrapper.callback.timeout=60
+      wrapper.cache.enabled=true
       # wrapper.auth.basic.someuser=somepassword
 
 # Values for grafana subchart.

--- a/charts/irs/values-pen.yaml
+++ b/charts/irs/values-pen.yaml
@@ -56,6 +56,7 @@ irs-aaswrapper:
       wrapper.consumer.edc.apikey.name=X-Api-Key
       wrapper.consumer.edc.apikey.value=123456
       wrapper.callback.timeout=60
+      wrapper.cache.enabled=true
       # wrapper.auth.basic.someuser=somepassword
 
 # Values for grafana subchart.

--- a/testdata-transform/reset-env.py
+++ b/testdata-transform/reset-env.py
@@ -4,25 +4,72 @@ import argparse
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+
+def delete_shells(url_, headers_):
+    while session.request(method="GET", url=url_ + "?pageSize=50", headers=headers_).json()["items"]:
+        response = session.request(method="GET", url=url_ + "?pageSize=50", headers=headers_)
+        response_json = response.json()
+        items = response_json["items"]
+        for item in items:
+            global_asset_id = item["identification"]
+            delete_response = session.request(method="DELETE", url=url_ + "/" + global_asset_id, headers=headers_)
+            print(delete_response)
+            if delete_response.status_code > 205:
+                print(global_asset_id)
+
+
+def delete_(url_, headers_):
+    response = session.request(method="GET", url=url_, headers=headers_)
+    values = response.json()
+    for value in values:
+        uid_ = value["id"]
+        delete_response = session.request(method="DELETE", url=url_ + "/" + uid_,
+                                          headers=headers_)
+        print(delete_response)
+        if delete_response.status_code > 205:
+            print(uid_)
+
+
+def delete_contracts(url_, headers_):
+    while session.request(method="GET", url=url_, headers=headers_).json():
+        delete_(url_, headers_)
+
+
+def delete_policies_and_assets(policy_url_, asset_url_, headers_):
+    while session.request(method="GET", url=policy_url_, headers=headers_).json():
+        delete_(policy_url_, headers_)
+
+        response = session.request(method="GET", url=asset_url_, headers=headers_)
+        values = response.json()
+        for value in values:
+            uid_ = value["properties"]["asset:prop:id"]
+            delete_response = session.request(method="DELETE", url=asset_url_ + "/" + str(uid_),
+                                              headers=headers_)
+            print(delete_response)
+            if delete_response.status_code > 205:
+                print(uid_)
+
+
 if __name__ == "__main__":
     # -a "https://irs-aas-registry.dev.demo.catena-x.net/registry/shell-descriptors"
-    # -e "https://irs-provider-controlplane.dev.demo.catena-x.net/data/contractdefinitions"
+    # -e1 "https://irs-provider-controlplane.dev.demo.catena-x.net/data/contractdefinitions"
+    # -e2 "https://irs-provider-controlplane2.dev.demo.catena-x.net/data/contractdefinitions"
+    # -e3 "https://irs-provider-controlplane3.dev.demo.catena-x.net/data/contractdefinitions"
     # -k '123456'
     parser = argparse.ArgumentParser(description="Script to delete testdata from CX Environment.",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("-a", "--aas", type=str, help="aas url", required=True)
-    parser.add_argument("-e", "--edc", type=str, help="edc url", required=True)
+    parser.add_argument("-e1", "--edc1", type=str, help="Public EDC provider control plane url 1", required=True)
+    parser.add_argument("-e2", "--edc2", type=str, help="Public EDC provider control plane url 2", required=True)
+    parser.add_argument("-e3", "--edc3", type=str, help="Public EDC provider control plane url 3", required=True)
     parser.add_argument("-k", "--apikey", type=str, help="edc api key", required=True)
 
     args = parser.parse_args()
     config = vars(args)
     edc_api_key = config.get("apikey")
     registry_url = config.get("aas") + "/registry/shell-descriptors"
-    edc_url = config.get("edc")
+    edc_urls = [config.get("edc1"), config.get("edc2"), config.get("edc3")]
 
-    controlplane_data_contracts = edc_url + "/data/contractdefinitions"
-    controlplane_data_policies = edc_url + "/data/policydefinitions"
-    controlplane_data_assets = edc_url + "/data/assets"
     headers = {
         'X-Api-Key': edc_api_key,
         'Content-Type': 'application/json'
@@ -30,49 +77,16 @@ if __name__ == "__main__":
 
     retries = Retry(total=5,
                     backoff_factor=0.1)
-
     session = requests.Session()
     session.mount('https://', HTTPAdapter(max_retries=retries))
 
-    while requests.request(method="GET", url=registry_url + "?pageSize=50", headers=headers).json()["items"]:
-        response = requests.request(method="GET", url=registry_url + "?pageSize=50", headers=headers)
-        response_json = response.json()
-        items = response_json["items"]
-        for item in items:
-            global_asset_id = item["identification"]
-            delete_response = requests.request(method="DELETE", url=registry_url + "/" + global_asset_id, headers=headers)
-            print(delete_response)
-            if delete_response.status_code > 205:
-                print(global_asset_id)
+    delete_shells(registry_url, headers)
 
-    while requests.request(method="GET", url=controlplane_data_contracts, headers=headers).json():
-        response = requests.request(method="GET", url=controlplane_data_contracts, headers=headers)
-        values = response.json()
-        for value in values:
-            uid_ = value["id"]
-            delete_response = requests.request(method="DELETE", url=controlplane_data_contracts + "/" + uid_,
-                                               headers=headers)
-            print(delete_response)
-            if delete_response.status_code > 205:
-                print(uid_)
+    for edc_url in edc_urls:
+        controlplane_data_contracts = edc_url + "/data/contractdefinitions"
+        controlplane_data_policies = edc_url + "/data/policydefinitions"
+        controlplane_data_assets = edc_url + "/data/assets"
 
-    while requests.request(method="GET", url=controlplane_data_policies, headers=headers).json():
-        response = requests.request(method="GET", url=controlplane_data_policies, headers=headers)
-        values = response.json()
-        for value in values:
-            uid_ = value["id"]
-            delete_response = requests.request(method="DELETE", url=controlplane_data_policies + "/" + uid_,
-                                               headers=headers)
-            print(delete_response)
-            if delete_response.status_code > 205:
-                print(uid_)
+        delete_contracts(controlplane_data_contracts, headers)
 
-        response = requests.request(method="GET", url=controlplane_data_assets, headers=headers)
-        values = response.json()
-        for value in values:
-            uid_ = value["properties"]["asset:prop:id"]
-            delete_response = requests.request(method="DELETE", url=controlplane_data_assets + "/" + str(uid_),
-                                               headers=headers)
-            print(delete_response)
-            if delete_response.status_code > 205:
-                print(uid_)
+        delete_policies_and_assets(controlplane_data_policies, controlplane_data_assets, headers)

--- a/testdata-transform/smallTestdata.json
+++ b/testdata-transform/smallTestdata.json
@@ -1,264 +1,513 @@
 {
   "https://catenax.io/schema/TestDataContainer/1.0.0": [
     {
-      "catenaXId": "urn:uuid:72589775-f8eb-48cc-ad5c-3cfe9122134b",
+      "catenaXId": "urn:uuid:913b1530-320e-44ee-878d-9c083ecedea0",
       "PlainObject": [
         {
           "BPN_OEM_C": "BPNL00000003AZQP",
           "BPN_SUB_TIER_B": "BPNL00000003AXS3",
           "BPN_SUB_TIER_A": "BPNL00000003B3NX",
-          "BATCH_CATHODE_1": "urn:uuid:3dcdf443-0fe7-44db-aae1-c3fcb9735535",
+          "BATCH_CATHODE_1": "urn:uuid:34b31f87-8d52-4f76-891a-37b0e3b473fb",
           "BPN_OEM_A": "BPNL00000003AYRE",
-          "BATCH_CATHODE_2": "urn:uuid:8ebfca3b-9364-40e6-bb66-ffec2db34059",
+          "BATCH_CATHODE_2": "urn:uuid:18bb4562-7d22-4ef9-9810-2307c33272e1",
           "BPN_OEM_B": "BPNL00000003AVTH",
           "BPN_IRS_TEST": "BPNL00000003AWSS",
+          "BPN_SUB_TIER_C": "BPNL00000000BJTL",
           "BPN_N_TIER_A": "BPNL00000003B0Q0",
-          "BATCH_SEALANT_1": "urn:uuid:749e3f34-5cd1-41a7-a44e-f24df1dba796",
-          "CREATION_DATE": "2022-05-13T16:29:16.037Z",
-          "BATCH_SEALANT_2": "urn:uuid:f0f677ac-b6d8-4423-9716-95825dba1b0e",
+          "BATCH_SEALANT_1": "urn:uuid:5d2fb50e-b469-4426-a5d1-3e5822d2f51c",
+          "CREATION_DATE": "2022-09-13T19:00:33.562Z",
+          "BATCH_SEALANT_2": "urn:uuid:37c57299-789e-4922-ac82-46d1946eb9e3",
           "AUTHOR": "christian.kabelin@partner.bmw.de",
-          "BATCH_GLUE_2": "urn:uuid:d4676d63-7151-4341-b4a1-3275a4bf99f4",
-          "BATCH_GLUE_1": "urn:uuid:62c1530c-accd-42a4-972d-0a7eb2740181",
+          "BATCH_GLUE_2": "urn:uuid:7ed2f7f4-ce46-4592-afd9-9061b2e38a9a",
+          "BATCH_GLUE_1": "urn:uuid:3f3a59a3-90b9-44f2-a123-498824e3e36e",
           "BPN_DISMANTLER": "BPNL00000003B6LU",
           "BPN_TIER_A": "BPNL00000003B2OM",
-          "BATCH_POLYAMID_1": "urn:uuid:f77e079e-5cd4-4747-bd8c-23ee8fe03d06",
+          "BPN_TIER_C": "BPNL00000003CSGV",
+          "BATCH_POLYAMID_1": "urn:uuid:2fb5533c-c07e-41f1-8245-b7030b352264",
           "BPN_TIER_B": "BPNL00000003B5MJ",
-          "BATCH_POLYAMID_2": "urn:uuid:c84977d5-d6dd-452a-9030-06aeba53a21e"
+          "BATCH_POLYAMID_2": "urn:uuid:73fb5246-644c-4829-9171-e9d3387d606f"
         }
       ]
     },
     {
-      "https://catenax.io/schema/CertificateOfDestruction/1.0.0": [
-        {
-          "productConditions": "at least 1990 model",
-          "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
-          "desiredPrice": {
-            "cost": 6.770644E37,
-            "currency": "EUR"
-          },
-          "returnConditions": "Wishes to buy",
-          "requestDate": "2022-01-01",
-          "needsReturn": true,
-          "latestReturnDate": "2025-01-01"
-        }
-      ],
-      "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
+      "catenaXId": "urn:uuid:c1b49038-81d6-4f0f-82aa-2df1c3a6f359",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003AYRE",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "KR-09",
-              "key": "ManufacturerPartID"
+              "value": "VS-27",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "OMA-TGFAYUHXFLHHUQQMPLTE",
-              "key": "PartInstanceID"
+              "value": "OMCVYLMEKOXCOEMCA",
+              "key": "partInstanceId"
             },
             {
-              "value": "OMA-TGFAYUHXFLHHUQQMPLTE",
-              "key": "VAN"
+              "value": "OMCVYLMEKOXCOEMCA",
+              "key": "van"
             }
           ],
           "manufacturingInformation": {
-            "date": "2014-11-18T09:23:55.000Z",
+            "date": "2020-03-10T19:13:22.000Z",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
+          "catenaXId": "urn:uuid:c1b49038-81d6-4f0f-82aa-2df1c3a6f359",
           "partTypeInformation": {
-            "manufacturerPartID": "KR-09",
+            "manufacturerPartId": "VS-27",
             "classification": "product",
-            "nameAtManufacturer": "Vehicle Hybrid"
+            "nameAtManufacturer": "Vehicle Fully Electric"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:e4040df4-0163-4235-96eb-a369beed51e6",
-          "idShort": "vehicle_hybrid.asm",
-          "specificAssetIds": [
+          "component": [
             {
-              "value": "OMA-TGFAYUHXFLHHUQQMPLTE",
-              "key": "http://pwc.t-systems.com/datamodel/common"
+              "materialName": "Iron",
+              "recycledContent": 0,
+              "materialClass": "1.1",
+              "quantity": {
+                "materialValue": 327.6,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "IR334"
             },
             {
-              "value": "KR-09",
-              "key": "urn:VR:wt.part.WTPart#"
+              "materialName": "Polyethylen",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "materialValue": 163.8,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "PE221"
             },
             {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003AYRE"
+              "materialName": "Polyamid6",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "materialValue": 40.95,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "POL6"
+            },
+            {
+              "materialName": "Aluminium",
+              "recycledContent": 0,
+              "materialClass": "2.1",
+              "quantity": {
+                "materialValue": 286.65,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "ALU331"
+            },
+            {
+              "materialName": "Kerosene waxes and hydrocarbon waxes, oxidized, lithium salts",
+              "recycledContent": 0,
+              "materialClass": "0.7",
+              "quantity": {
+                "materialValue": 109.2,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "W123"
+            },
+            {
+              "materialName": "Glue",
+              "recycledContent": 0,
+              "materialClass": "6.2",
+              "quantity": {
+                "materialValue": 54.6,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "GL338"
+            },
+            {
+              "materialName": "Carbon Steel",
+              "recycledContent": 0,
+              "materialClass": "1.1.2",
+              "quantity": {
+                "materialValue": 382.2,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CS2"
+            },
+            {
+              "materialName": "Cooper",
+              "recycledContent": 0,
+              "materialClass": "3.1",
+              "quantity": {
+                "materialValue": 250.2,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CO7"
+            },
+            {
+              "materialName": "Rubber",
+              "recycledContent": 0,
+              "materialClass": "5.3",
+              "quantity": {
+                "materialValue": 7.8,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "R22"
+            },
+            {
+              "materialName": "Textiles",
+              "recycledContent": 0,
+              "materialClass": "5.5.2",
+              "quantity": {
+                "materialValue": 5.12,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "TEX1"
             }
-          ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Vehicle Hybrid"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003AYRE.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003AYRE/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "assemblyPartRelationship",
-              "idShort": "assembly-part-relationship"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb"
-            ]
-          }
+          ]
         }
       ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
+          "catenaXId": "urn:uuid:c1b49038-81d6-4f0f-82aa-2df1c3a6f359",
           "childParts": [
             {
               "quantity": {
                 "quantityNumber": 1,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
-                  "lexicalValue": "piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562"
+              "childCatenaXId": "urn:uuid:b848cfad-d0c4-4cd4-92ac-9ac6fa52e71f"
             },
             {
               "quantity": {
                 "quantityNumber": 1,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
-                  "lexicalValue": "piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc"
+              "childCatenaXId": "urn:uuid:a9abb642-5cc6-4ec1-8ea6-67a6df56733d"
             },
             {
               "quantity": {
                 "quantityNumber": 1,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
-                  "lexicalValue": "piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a"
+              "childCatenaXId": "urn:uuid:40b2bfeb-10f0-4506-9cc0-64bd0f28d105"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:251667e0-40fb-42b8-9dbb-bd6480fb7475"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:7872d5d6-d5b7-4f76-b2ed-95fd8c2a6a35"
             }
           ]
         }
       ],
-      "https://catenax.io/schema/Batch/1.0.0": [
+      "https://catenax.io/schema/VehicleProductDescription/1.0.0": [
         {
-          "localIdentifiers": [
+          "bodyVariant": "Sedan",
+          "catenaXId": "urn:uuid:c1b49038-81d6-4f0f-82aa-2df1c3a6f359",
+          "engine": {
+            "size": 2998,
+            "power": 143
+          },
+          "emptyWeight": 1.73,
+          "fuel": "electric",
+          "vehicleModel": "Vehicle Fully Electric",
+          "productionDateGMT": "2010-01-01",
+          "equipmentVariants": [
             {
-              "value": "BID12345678",
-              "key": "BatchID"
+              "code": "A248B",
+              "description": "steering wheel heating",
+              "group": "special equipment"
             }
           ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
+          "anonymisedIdentifier": "sOMtThyhVNDWUZNRcBaQXXI",
+          "mileage": [
+            {
+              "mileagePhase": "as maintained by workshop",
+              "mileageTimestamp": "2022-04-01T20:09:59.976Z",
+              "mileageDistance": 120000
+            }
+          ]
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562",
+      "catenaXId": "urn:uuid:b848cfad-d0c4-4cd4-92ac-9ac6fa52e71f",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
-              "value": "BPNL00000003B2OM",
-              "key": "ManufacturerID"
+              "value": "BPNL00000003CSGV",
+              "key": "manufacturerId"
             },
             {
-              "value": "1O222E8-43",
-              "key": "ManufacturerPartID"
+              "value": "22782277-50",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-733616531805581150452604",
-              "key": "PartInstanceID"
+              "value": "NO-581727375022348614370011",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562",
+          "catenaXId": "urn:uuid:b848cfad-d0c4-4cd4-92ac-9ac6fa52e71f",
           "partTypeInformation": {
-            "manufacturerPartID": "1O222E8-43",
+            "manufacturerPartId": "22782277-50",
+            "customerPartId": "22782277-50",
+            "classification": "component",
+            "nameAtManufacturer": "Door f-l",
+            "nameAtCustomer": "Door front-left"
+          }
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:b848cfad-d0c4-4cd4-92ac-9ac6fa52e71f",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:60d621a0-4824-4b4b-8eaf-0dfaa7b64845"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:60d621a0-4824-4b4b-8eaf-0dfaa7b64845",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000000BJTL",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "95657762-59",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-318158597726962733975411",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:60d621a0-4824-4b4b-8eaf-0dfaa7b64845",
+          "partTypeInformation": {
+            "manufacturerPartId": "95657762-59",
+            "customerPartId": "95657762-59",
+            "classification": "component",
+            "nameAtManufacturer": "Door Key",
+            "nameAtCustomer": "Door Key"
+          }
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:a9abb642-5cc6-4ec1-8ea6-67a6df56733d",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003CSGV",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "95657362-64",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-081062276256899197422790",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:a9abb642-5cc6-4ec1-8ea6-67a6df56733d",
+          "partTypeInformation": {
+            "manufacturerPartId": "33740332-54",
+            "customerPartId": "33740332-54",
+            "classification": "component",
+            "nameAtManufacturer": "Door f-r",
+            "nameAtCustomer": "Door front-right"
+          }
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:a9abb642-5cc6-4ec1-8ea6-67a6df56733d",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:31b47307-1b0d-4f19-87e5-b25c147b98c1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:31b47307-1b0d-4f19-87e5-b25c147b98c1",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000000BJTL",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "95657762-59",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-285501644942341413344914",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:31b47307-1b0d-4f19-87e5-b25c147b98c1",
+          "partTypeInformation": {
+            "manufacturerPartId": "95657762-59",
+            "customerPartId": "95657762-59",
+            "classification": "component",
+            "nameAtManufacturer": "Door Key",
+            "nameAtCustomer": "Door Key"
+          }
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:40b2bfeb-10f0-4506-9cc0-64bd0f28d105",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003B2OM",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "1O222E8-43",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-581165466695471578753351",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:40b2bfeb-10f0-4506-9cc0-64bd0f28d105",
+          "partTypeInformation": {
+            "manufacturerPartId": "1O222E8-43",
             "customerPartId": "1O222E8-43",
             "classification": "component",
             "nameAtManufacturer": "Transmission",
@@ -266,1657 +515,927 @@
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:e7f913e3-cc08-42e6-a8b4-20aa5562b2a3",
-          "idShort": "transmission.asm",
-          "specificAssetIds": [
+          "component": [
             {
-              "value": "NO-733616531805581150452604",
-              "key": "http://pwc.t-systems.com/datamodel/common"
+              "materialName": "Carbon Steel",
+              "recycledContent": 0,
+              "materialClass": "1.1.2",
+              "quantity": {
+                "materialValue": 72.843,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CS2"
             },
             {
-              "value": "1O222E8-43",
-              "key": "urn:VR:wt.part.WTPart#"
+              "materialName": "Oil",
+              "recycledContent": 0,
+              "materialClass": "9.2",
+              "quantity": {
+                "materialValue": 6.9,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "liquid",
+              "materialAbbreviation": "SAE40"
             },
             {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003B2OM"
+              "materialName": "Copper",
+              "recycledContent": 0,
+              "materialClass": "3.1",
+              "quantity": {
+                "materialValue": 1.2,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CO7"
             }
-          ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Transmission"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "assemblyPartRelationship",
-              "idShort": "assembly-part-relationship"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562"
-            ]
-          }
+          ]
         }
       ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562",
+          "catenaXId": "urn:uuid:40b2bfeb-10f0-4506-9cc0-64bd0f28d105",
           "childParts": [
             {
               "quantity": {
                 "quantityNumber": "0.2014",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
-                  "lexicalValue": "kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae"
+              "childCatenaXId": "urn:uuid:2fbd1757-1fd1-4b36-ba7b-2b29deb1c55f"
             },
             {
               "quantity": {
                 "quantityNumber": 1,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
-                  "lexicalValue": "piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2"
+              "childCatenaXId": "urn:uuid:f2cac93e-5906-44ce-b8db-dc197890d6cd"
             },
             {
               "quantity": {
                 "quantityNumber": "0.2341",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
-                  "lexicalValue": "kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef"
+              "childCatenaXId": "urn:uuid:1dbc0240-89e1-446c-aaa8-b2c3d1298eaa"
             }
           ]
         }
       ],
-      "https://catenax.io/schema/Batch/1.0.0": [
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
         {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
+          "diameter": "380",
+          "length": "810",
+          "width": "590",
+          "weight": "85",
+          "height": "610"
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+      "https://catenax.io/schema/batch/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003B0Q0",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "01697F7-65",
-              "key": "ManufacturerPartID"
+              "value": "66586Z4-32",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-947880349904267845729159",
-              "key": "PartInstanceID"
+              "value": "NO-453182371085327841586911",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae",
+          "catenaXId": "urn:uuid:2fbd1757-1fd1-4b36-ba7b-2b29deb1c55f",
           "partTypeInformation": {
-            "manufacturerPartID": "01697F7-65",
-            "customerPartId": "01697F7-65",
+            "manufacturerPartId": "66586Z4-32",
+            "customerPartId": "66586Z4-32",
             "classification": "component",
             "nameAtManufacturer": "Engineering Plastics",
             "nameAtCustomer": "Engineering Plastics"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "catenaXId": "urn:uuid:2fbd1757-1fd1-4b36-ba7b-2b29deb1c55f",
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:af63a726-bc49-47e5-b9f0-d1f42f000791",
-          "idShort": "engineering_plastics.asm",
-          "specificAssetIds": [
+          "materialName": "Engineering Plastics",
+          "materialClass": "5.1",
+          "component": [
             {
-              "value": "NO-947880349904267845729159",
-              "key": "http://pwc.t-systems.com/datamodel/common"
+              "materialName": "PA66",
+              "recycledContent": 0,
+              "materialClass": "5.1",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 70
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "PA66"
             },
             {
-              "value": "01697F7-65",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003B0Q0"
+              "materialName": "GF-Faser",
+              "recycledContent": 0,
+              "materialClass": "5.1",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 30
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "GF30"
             }
           ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Engineering Plastics"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae"
-            ]
-          }
-        }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
+          "recycledContent": 0
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2",
+      "catenaXId": "urn:uuid:f2cac93e-5906-44ce-b8db-dc197890d6cd",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003B3NX",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "37754B7-76",
-              "key": "ManufacturerPartID"
+              "value": "92165M0-86",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-159040131155901488695376",
-              "key": "PartInstanceID"
+              "value": "NO-953338478923471950094627",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2",
+          "catenaXId": "urn:uuid:f2cac93e-5906-44ce-b8db-dc197890d6cd",
           "partTypeInformation": {
-            "manufacturerPartID": "37754B7-76",
-            "customerPartId": "37754B7-76",
+            "manufacturerPartId": "92165M0-86",
+            "customerPartId": "92165M0-86",
             "classification": "component",
             "nameAtManufacturer": "Sensor",
             "nameAtCustomer": "Sensor"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
-        {
-          "identification": "urn:uuid:ed6f38ce-2c96-458d-a15a-3966e05de942",
-          "idShort": "sensor.asm",
-          "specificAssetIds": [
-            {
-              "value": "NO-159040131155901488695376",
-              "key": "http://pwc.t-systems.com/datamodel/common"
-            },
-            {
-              "value": "37754B7-76",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003B3NX"
-            }
-          ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Sensor"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B3NX.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B3NX/urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "assemblyPartRelationship",
-              "idShort": "assembly-part-relationship"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2"
-            ]
-          }
-        }
-      ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2",
+          "catenaXId": "urn:uuid:f2cac93e-5906-44ce-b8db-dc197890d6cd",
           "childParts": [
             {
               "quantity": {
                 "quantityNumber": "0.1908",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
-                  "lexicalValue": "kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31"
+              "childCatenaXId": "urn:uuid:9330b804-03ba-4b5a-93af-9a20c630501d"
             }
           ]
-        }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+      "https://catenax.io/schema/batch/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003B0Q0",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "98801V5-17",
-              "key": "ManufacturerPartID"
+              "value": "02371L9-62",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-056604022229087145032390",
-              "key": "PartInstanceID"
+              "value": "NO-526584782217105635478100",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31",
+          "catenaXId": "urn:uuid:9330b804-03ba-4b5a-93af-9a20c630501d",
           "partTypeInformation": {
-            "manufacturerPartID": "98801V5-17",
-            "customerPartId": "98801V5-17",
+            "manufacturerPartId": "02371L9-62",
+            "customerPartId": "02371L9-62",
             "classification": "component",
             "nameAtManufacturer": "NTIER Product",
             "nameAtCustomer": "NTIER Product"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "catenaXId": "urn:uuid:9330b804-03ba-4b5a-93af-9a20c630501d",
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:367922d4-ee3a-40a3-b0f9-8e34c5a2ab51",
-          "idShort": "ntier_product.asm",
-          "specificAssetIds": [
+          "materialName": "NTIER Product",
+          "materialClass": "5.5",
+          "component": [
             {
-              "value": "NO-056604022229087145032390",
-              "key": "http://pwc.t-systems.com/datamodel/common"
+              "materialName": "Aluminium oxide",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 60
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": ""
             },
             {
-              "value": "98801V5-17",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003B0Q0"
+              "materialName": "Other",
+              "recycledContent": 0,
+              "materialClass": "5.5.2",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 40
+              },
+              "aggregateState": "",
+              "materialAbbreviation": ""
             }
           ],
-          "description": [
-            {
-              "language": "en",
-              "text": "NTIER Product"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31"
-            ]
-          }
-        }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
+          "recycledContent": 0
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+      "https://catenax.io/schema/batch/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003AXS3",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "31008B0-49",
-              "key": "ManufacturerPartID"
+              "value": "69123K1-67",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-825423826078402432465664",
-              "key": "PartInstanceID"
+              "value": "NO-443885565962785719429466",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef",
+          "catenaXId": "urn:uuid:1dbc0240-89e1-446c-aaa8-b2c3d1298eaa",
           "partTypeInformation": {
-            "manufacturerPartID": "31008B0-49",
-            "customerPartId": "31008B0-49",
+            "manufacturerPartId": "69123K1-67",
+            "customerPartId": "69123K1-67",
             "classification": "component",
             "nameAtManufacturer": "Glue",
             "nameAtCustomer": "Glue"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "catenaXId": "urn:uuid:1dbc0240-89e1-446c-aaa8-b2c3d1298eaa",
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:48af44a2-e853-4b4f-a311-95794f542696",
-          "idShort": "glue.asm",
-          "specificAssetIds": [
+          "component": [
             {
-              "value": "NO-825423826078402432465664",
-              "key": "http://pwc.t-systems.com/datamodel/common"
-            },
-            {
-              "value": "31008B0-49",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003AXS3"
+              "materialName": "Glue",
+              "materialClass": "6.2",
+              "quantity": {
+                "materialValue": 0,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "weight": "0.2341",
+              "materialAbbreviation": "GL338"
             }
-          ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Glue"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003AXS3.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003AXS3/urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "assemblyPartRelationship",
-              "idShort": "assembly-part-relationship"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef"
-            ]
-          }
+          ]
         }
       ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef",
+          "catenaXId": "urn:uuid:1dbc0240-89e1-446c-aaa8-b2c3d1298eaa",
           "childParts": []
-        }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc",
+      "catenaXId": "urn:uuid:251667e0-40fb-42b8-9dbb-bd6480fb7475",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003B5MJ",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "83238F4-36",
-              "key": "ManufacturerPartID"
+              "value": "21045M2-94",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-354879221683258717359442",
-              "key": "PartInstanceID"
+              "value": "NO-097450000156375842820501",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc",
+          "catenaXId": "urn:uuid:251667e0-40fb-42b8-9dbb-bd6480fb7475",
           "partTypeInformation": {
-            "manufacturerPartID": "83238F4-36",
-            "customerPartId": "83238F4-36",
+            "manufacturerPartId": "21045M2-94",
+            "customerPartId": "21045M2-94",
             "classification": "component",
             "nameAtManufacturer": "ECU",
             "nameAtCustomer": "ECU"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:8f2b558a-62f8-44f1-b2e4-6b5ad4bbbfd9",
-          "idShort": "ecu.asm",
-          "specificAssetIds": [
+          "component": [
             {
-              "value": "NO-354879221683258717359442",
-              "key": "http://pwc.t-systems.com/datamodel/common"
-            },
-            {
-              "value": "83238F4-36",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003B5MJ"
+              "materialName": "Glue",
+              "recycledContent": 0,
+              "materialClass": "6.2",
+              "quantity": {
+                "materialValue": 0.3301,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "GL338"
             }
-          ],
-          "description": [
-            {
-              "language": "en",
-              "text": "ECU"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B5MJ.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B5MJ/urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "assemblyPartRelationship",
-              "idShort": "assembly-part-relationship"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc"
-            ]
-          }
+          ]
         }
       ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc",
+          "catenaXId": "urn:uuid:251667e0-40fb-42b8-9dbb-bd6480fb7475",
           "childParts": [
             {
               "quantity": {
                 "quantityNumber": "0.3301",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
-                  "lexicalValue": "kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34"
+              "childCatenaXId": "urn:uuid:578eb7d1-63a2-4017-80c6-271dddbedfd8"
             },
             {
               "quantity": {
                 "quantityNumber": 1,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
-                  "lexicalValue": "piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640"
+              "childCatenaXId": "urn:uuid:ca629e9d-be47-4a14-a5de-dc8d19f6e4a0"
             },
             {
               "quantity": {
                 "quantityNumber": "0.2001",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
-                  "lexicalValue": "kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87"
+              "childCatenaXId": "urn:uuid:c7195ee4-675c-4a6c-877a-114103600c19"
             }
           ]
-        }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+      "https://catenax.io/schema/batch/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003AXS3",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "91471Z0-84",
-              "key": "ManufacturerPartID"
+              "value": "47304P9-58",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-182660425740222655242543",
-              "key": "PartInstanceID"
+              "value": "NO-082105746702509852353816",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34",
+          "catenaXId": "urn:uuid:578eb7d1-63a2-4017-80c6-271dddbedfd8",
           "partTypeInformation": {
-            "manufacturerPartID": "91471Z0-84",
-            "customerPartId": "91471Z0-84",
+            "manufacturerPartId": "47304P9-58",
+            "customerPartId": "47304P9-58",
             "classification": "component",
             "nameAtManufacturer": "Glue",
             "nameAtCustomer": "Glue"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "catenaXId": "urn:uuid:578eb7d1-63a2-4017-80c6-271dddbedfd8",
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:918f8caa-d613-4f4a-8711-8c86bf0989ab",
-          "idShort": "glue.asm",
-          "specificAssetIds": [
+          "materialName": "Glue",
+          "materialClass": "5.5",
+          "component": [
             {
-              "value": "NO-182660425740222655242543",
-              "key": "http://pwc.t-systems.com/datamodel/common"
+              "materialName": "Aluminium oxide",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 70
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "AL7"
             },
             {
-              "value": "91471Z0-84",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003AXS3"
+              "materialName": "Other",
+              "recycledContent": 0,
+              "materialClass": "5.5.2",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 30
+              },
+              "aggregateState": "",
+              "materialAbbreviation": ""
             }
           ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Glue"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34"
-            ]
-          }
-        }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
+          "recycledContent": 0
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640",
+      "catenaXId": "urn:uuid:ca629e9d-be47-4a14-a5de-dc8d19f6e4a0",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003B3NX",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "65847F9-69",
-              "key": "ManufacturerPartID"
+              "value": "36739T1-40",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-628797496367807957077265",
-              "key": "PartInstanceID"
+              "value": "NO-178880363412841367535223",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640",
+          "catenaXId": "urn:uuid:ca629e9d-be47-4a14-a5de-dc8d19f6e4a0",
           "partTypeInformation": {
-            "manufacturerPartID": "65847F9-69",
-            "customerPartId": "65847F9-69",
+            "manufacturerPartId": "36739T1-40",
+            "customerPartId": "36739T1-40",
             "classification": "component",
             "nameAtManufacturer": "Sensor",
             "nameAtCustomer": "Sensor"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
-        {
-          "identification": "urn:uuid:f8a3a7f6-6817-41fa-8f0b-8dc4d6db003f",
-          "idShort": "sensor.asm",
-          "specificAssetIds": [
-            {
-              "value": "NO-628797496367807957077265",
-              "key": "http://pwc.t-systems.com/datamodel/common"
-            },
-            {
-              "value": "65847F9-69",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003B3NX"
-            }
-          ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Sensor"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B3NX.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B3NX/urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "assemblyPartRelationship",
-              "idShort": "assembly-part-relationship"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640"
-            ]
-          }
-        }
-      ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640",
+          "catenaXId": "urn:uuid:ca629e9d-be47-4a14-a5de-dc8d19f6e4a0",
           "childParts": [
             {
               "quantity": {
                 "quantityNumber": "0.1908",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
-                  "lexicalValue": "kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9"
+              "childCatenaXId": "urn:uuid:f3ee258d-83c3-43cf-bf94-9852fc9d5d62"
             }
           ]
         }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
-        }
       ]
     },
     {
-      "catenaXId": "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+      "https://catenax.io/schema/batch/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003B0Q0",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "74268H5-13",
-              "key": "ManufacturerPartID"
+              "value": "14830M8-91",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-565359302028822441908953",
-              "key": "PartInstanceID"
+              "value": "NO-090544509718531503998683",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9",
+          "catenaXId": "urn:uuid:f3ee258d-83c3-43cf-bf94-9852fc9d5d62",
           "partTypeInformation": {
-            "manufacturerPartID": "74268H5-13",
-            "customerPartId": "74268H5-13",
+            "manufacturerPartId": "14830M8-91",
+            "customerPartId": "14830M8-91",
             "classification": "component",
             "nameAtManufacturer": "Engineering Plastics",
             "nameAtCustomer": "Engineering Plastics"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "catenaXId": "urn:uuid:f3ee258d-83c3-43cf-bf94-9852fc9d5d62",
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:e51ac8ed-f7b3-49fd-a781-b5c5d16b623e",
-          "idShort": "engineering_plastics.asm",
-          "specificAssetIds": [
+          "materialName": "Engineering Plastics",
+          "materialClass": "5.1",
+          "component": [
             {
-              "value": "NO-565359302028822441908953",
-              "key": "http://pwc.t-systems.com/datamodel/common"
+              "materialName": "PA66",
+              "recycledContent": 0,
+              "materialClass": "5.1",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 70
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "PA66"
             },
             {
-              "value": "74268H5-13",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003B0Q0"
+              "materialName": "GF-Faser",
+              "recycledContent": 0,
+              "materialClass": "5.1",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 30
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "GF30"
             }
           ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Engineering Plastics"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9"
-            ]
-          }
-        }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
+          "recycledContent": 0
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87",
+      "catenaXId": "urn:uuid:c7195ee4-675c-4a6c-877a-114103600c19",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003B0Q0",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "55269I8-71",
-              "key": "ManufacturerPartID"
+              "value": "72391Y8-16",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-340460948192054950891951",
-              "key": "PartInstanceID"
+              "value": "NO-321436075520371144418631",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87",
+          "catenaXId": "urn:uuid:c7195ee4-675c-4a6c-877a-114103600c19",
           "partTypeInformation": {
-            "manufacturerPartID": "55269I8-71",
-            "customerPartId": "55269I8-71",
+            "manufacturerPartId": "72391Y8-16",
+            "customerPartId": "72391Y8-16",
             "classification": "component",
             "nameAtManufacturer": "Engineering Plastics",
             "nameAtCustomer": "Engineering Plastics"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:2b47d838-4bbe-4867-951a-83192e3f4e2f",
-          "idShort": "engineering_plastics.asm",
-          "specificAssetIds": [
+          "materialName": "Engineering Plastics",
+          "materialClass": "5.1",
+          "component": [
             {
-              "value": "NO-340460948192054950891951",
-              "key": "http://pwc.t-systems.com/datamodel/common"
+              "materialName": "PA66",
+              "recycledContent": 0,
+              "materialClass": "5.1",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 70
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "PA66"
             },
             {
-              "value": "55269I8-71",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003B0Q0"
+              "materialName": "GF-Faser",
+              "recycledContent": 0,
+              "materialClass": "5.1",
+              "quantity": {
+                "unit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:percent"
+                },
+                "value": 30
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "GF30"
             }
           ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Engineering Plastics"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87"
-            ]
-          }
-        }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
+          "recycledContent": 0
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a",
+      "catenaXId": "urn:uuid:7872d5d6-d5b7-4f76-b2ed-95fd8c2a6a35",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003AYRE",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "95657362-83",
-              "key": "ManufacturerPartID"
+              "value": "38049661-08",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-369202025208677072946181",
-              "key": "PartInstanceID"
+              "value": "NO-329231350304036846103634",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a",
+          "catenaXId": "urn:uuid:7872d5d6-d5b7-4f76-b2ed-95fd8c2a6a35",
           "partTypeInformation": {
-            "manufacturerPartID": "95657362-83",
-            "customerPartId": "95657362-83",
+            "manufacturerPartId": "38049661-08",
+            "customerPartId": "38049661-08",
             "classification": "component",
             "nameAtManufacturer": "Battery",
             "nameAtCustomer": "Battery"
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:80d060c6-4f79-490a-8a8c-ec230bff786c",
-          "idShort": "battery.asm",
-          "specificAssetIds": [
+          "component": [
             {
-              "value": "NO-369202025208677072946181",
-              "key": "http://pwc.t-systems.com/datamodel/common"
+              "materialName": "Cooper",
+              "recycledContent": 0,
+              "materialClass": "3.1",
+              "quantity": {
+                "materialValue": 5.4,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CO7"
             },
             {
-              "value": "95657362-83",
-              "key": "urn:VR:wt.part.WTPart#"
+              "materialName": "Polyamid6",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "materialValue": 11.75,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "POL6"
             },
             {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003AYRE"
+              "materialName": "Carbon Steel",
+              "recycledContent": 0,
+              "materialClass": "1.1.2",
+              "quantity": {
+                "materialValue": 1.23,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CS2"
             }
-          ],
-          "description": [
-            {
-              "language": "en",
-              "text": "Battery"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003AYRE.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003AYRE/urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "assemblyPartRelationship",
-              "idShort": "assembly-part-relationship"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a"
-            ]
-          }
+          ]
         }
       ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a",
+          "catenaXId": "urn:uuid:7872d5d6-d5b7-4f76-b2ed-95fd8c2a6a35",
           "childParts": [
             {
               "quantity": {
                 "quantityNumber": 1,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
-                  "lexicalValue": "piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978"
+              "childCatenaXId": "urn:uuid:9afe9e1b-a7e4-4fa0-81c6-6968278a755e"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:3ea62eb9-de33-485f-921d-f6420e449646"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:579b6eb3-3664-4625-bac8-b847602b1c07"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:d98f5071-f06f-4fa6-bec1-932dbe1ae99d"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:6d81200d-2e56-4d77-ba5a-9c3afc7b9886"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:7c10ee16-7362-4858-8cf5-63f18c8b5a32"
             }
           ]
         }
       ],
-      "https://catenax.io/schema/Batch/1.0.0": [
+      "https://catenax.io/schema/ReturnRequest/0.1.1": [
         {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
+          "productConditions": "at least 1990 model",
+          "desiredPrice": {
+            "cost": 15340,
+            "currency": "EUR"
           },
-          "catenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
+          "returnConditions": "Wishes to buy",
+          "requestDate": "2022-01-01",
+          "needsReturn": true,
+          "latestReturnDate": "2025-01-01"
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978",
+      "catenaXId": "urn:uuid:9afe9e1b-a7e4-4fa0-81c6-6968278a755e",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003AYRE",
-              "key": "ManufacturerID"
+              "key": "manufacturerId"
             },
             {
-              "value": "8840838-04",
-              "key": "ManufacturerPartID"
+              "value": "8840837-48",
+              "key": "manufacturerPartId"
             },
             {
-              "value": "NO-397646649734958738335866",
-              "key": "PartInstanceID"
+              "value": "NO-390644514189558711866299",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978",
+          "catenaXId": "urn:uuid:9afe9e1b-a7e4-4fa0-81c6-6968278a755e",
           "partTypeInformation": {
-            "manufacturerPartID": "8840838-04",
+            "manufacturerPartId": "8840838-04",
             "customerPartId": "8840838-04",
             "classification": "component",
             "nameAtManufacturer": "HV MODUL",
@@ -1924,231 +1443,8 @@
           }
         }
       ],
-      "https://catenax.io/schema/AAS/3.0": [
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
         {
-          "identification": "urn:uuid:9ec14d43-c009-464a-9717-86cf28d4df28",
-          "idShort": "hv_modul.asm",
-          "specificAssetIds": [
-            {
-              "value": "NO-397646649734958738335866",
-              "key": "http://pwc.t-systems.com/datamodel/common"
-            },
-            {
-              "value": "8840838-04",
-              "key": "urn:VR:wt.part.WTPart#"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003AYRE"
-            }
-          ],
-          "description": [
-            {
-              "language": "en",
-              "text": "HV MODUL"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003AYRE.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003AYRE/urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "assemblyPartRelationship",
-              "idShort": "assembly-part-relationship"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "serialPartTypization",
-              "idShort": "serial-part-typization"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978"
-            ]
-          }
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978",
-          "childParts": []
-        }
-      ],
-      "https://catenax.io/schema/Batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BID12345678",
-              "key": "BatchID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "HUR"
-          },
-          "catenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978",
-          "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
-          }
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "ManufacturerID"
-            },
-            {
-              "value": "8840838-04",
-              "key": "ManufacturerPartID"
-            },
-            {
-              "value": "NO-397646649734958738335866",
-              "key": "PartInstanceID"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa",
-          "partTypeInformation": {
-            "manufacturerPartID": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "HV MODUL",
-            "nameAtCustomer": "HV MODUL"
-          }
-        }
-      ],
-      "https://catenax.io/schema/AAS/3.0": [
-        {
-          "description": [
-            {
-              "language": "en",
-              "text": "HV MODUL"
-            }
-          ],
-          "globalAssetId": {
-            "value": [
-              "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa"
-            ]
-          },
-          "idShort": "hv_modul.asm",
-          "identification": "urn:uuid:9ec14d43-c009-464a-9717-86cf28d4df28",
-          "specificAssetIds": [
-            {
-              "key": "http://pwc.t-systems.com/datamodel/common",
-              "value": "NO-397646649734958738335866"
-            },
-            {
-              "key": "urn:VR:wt.part.WTPart#",
-              "value": "8840838-04"
-            },
-            {
-              "key": "ManufacturerId",
-              "value": "BPNL00000003AYRE"
-            }
-          ],
-          "submodelDescriptors": [
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003AYRE.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider-control-plane:8282/BPNL00000003AYRE/urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa-urn:uuid:3064f87d-5e4a-496b-9685-c1cf3e113198/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "urn:uuid:3064f87d-5e4a-496b-9685-c1cf3e113198",
-              "idShort": "assembly-part-relationship"
-            },
-            {
-              "semanticId": [
-                {
-                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
-                }
-              ],
-              "endpoints": [
-                {
-                  "interface": "https://BPNL00000003B2OM.connector",
-                  "protocolInformation": {
-                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
-                    "endpointProtocolVersion": "1.0RC02",
-                    "endpointProtocol": "AAS/SUBMODEL"
-                  }
-                }
-              ],
-              "identification": "batch",
-              "idShort": "batch"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa",
           "component": [
             {
               "materialName": "Cooper",
@@ -2157,8 +1453,8 @@
               "quantity": {
                 "materialValue": 1.2,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
-                  "lexicalValue": "kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
                 }
               },
               "aggregateState": "solid",
@@ -2171,8 +1467,8 @@
               "quantity": {
                 "materialValue": 2.5,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
-                  "lexicalValue": "kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
                 }
               },
               "aggregateState": "solid",
@@ -2185,8 +1481,8 @@
               "quantity": {
                 "materialValue": 0.23,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
-                  "lexicalValue": "kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
                 }
               },
               "aggregateState": "solid",
@@ -2195,26 +1491,4045 @@
           ]
         }
       ],
-      "https://catenax.io/schema/Batch/1.0.0": [
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:9afe9e1b-a7e4-4fa0-81c6-6968278a755e",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 0.11,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:24bdb582-944b-45e9-80ab-062474e5e7d7"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:d0d289a1-a54a-4ccb-a21c-70e7037f4243"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:43cf3ca4-20d5-4c54-8fa9-0a43c2d966c4"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:c0e2bde1-b406-4d98-9a92-5be8d3b83099"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/batch/1.0.0": [
         {
           "localIdentifiers": [
             {
-              "value": "BID12345678",
-              "key": "BatchID"
+              "value": "BPNL00000003AXS3",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "9A047C7-01",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-931692691590612649332063",
+              "key": "partInstanceId"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
-            "country": "HUR"
+            "country": "DEU"
           },
-          "catenaXId": "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa",
+          "catenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf",
           "partTypeInformation": {
-            "manufacturerPartId": "123-0.740-3434-A",
-            "customerPartId": "PRT-12345",
-            "classification": "product",
-            "nameAtManufacturer": "Mirror left",
-            "nameAtCustomer": "side element A"
+            "manufacturerPartId": "9A047C7-01",
+            "customerPartId": "9A047C7-01",
+            "classification": "component",
+            "nameAtManufacturer": "Sealant",
+            "nameAtCustomer": "Sealant"
           }
+        }
+      ],
+      "catenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf",
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+        {
+          "component": [
+            {
+              "materialName": "Sealant",
+              "materialClass": "6.3",
+              "quantity": {
+                "materialValue": 0,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "weight": "0.11",
+              "materialAbbreviation": "SEL3321"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2012-11-07T08:35:40.695Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-03T20:48:12.696Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:24bdb582-944b-45e9-80ab-062474e5e7d7",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-301915402074061381393752",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:24bdb582-944b-45e9-80ab-062474e5e7d7",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2017-01-15T08:31:26.703Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-17T17:35:14.703Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:d0d289a1-a54a-4ccb-a21c-70e7037f4243",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-820523752865804896998892",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:d0d289a1-a54a-4ccb-a21c-70e7037f4243",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2017-01-06T02:55:52.710Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-09T19:18:11.710Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:43cf3ca4-20d5-4c54-8fa9-0a43c2d966c4",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-743319028656688478281705",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:43cf3ca4-20d5-4c54-8fa9-0a43c2d966c4",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2014-07-22T10:56:01.716Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-04T06:14:39.716Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:c0e2bde1-b406-4d98-9a92-5be8d3b83099",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-239258021244659013481041",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:c0e2bde1-b406-4d98-9a92-5be8d3b83099",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:3ea62eb9-de33-485f-921d-f6420e449646",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840837-48",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-712848562793023650626166",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:3ea62eb9-de33-485f-921d-f6420e449646",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "HV MODUL",
+            "nameAtCustomer": "HV MODUL"
+          }
+        }
+      ],
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+        {
+          "component": [
+            {
+              "materialName": "Cooper",
+              "recycledContent": 0,
+              "materialClass": "3.1",
+              "quantity": {
+                "materialValue": 1.2,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CO7"
+            },
+            {
+              "materialName": "Polyamid6",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "materialValue": 2.5,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "POL6"
+            },
+            {
+              "materialName": "Carbon Steel",
+              "recycledContent": 0,
+              "materialClass": "1.1.2",
+              "quantity": {
+                "materialValue": 0.23,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CS2"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:3ea62eb9-de33-485f-921d-f6420e449646",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 0.11,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:ab614d99-8c8c-4fdf-bc44-e13b521a9a82"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:2d8ee54d-5a7c-4157-afda-d96d0e32cbfa"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:0f261333-0621-459d-8b7f-de50e61a16eb"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:77f4acdb-2e6e-484f-8472-e73120cd53ef"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AXS3",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "9A047C7-01",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-170808344553200705971613",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420",
+          "partTypeInformation": {
+            "manufacturerPartId": "9A047C7-01",
+            "customerPartId": "9A047C7-01",
+            "classification": "component",
+            "nameAtManufacturer": "Sealant",
+            "nameAtCustomer": "Sealant"
+          }
+        }
+      ],
+      "catenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420",
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+        {
+          "component": [
+            {
+              "materialName": "Sealant",
+              "materialClass": "6.3",
+              "quantity": {
+                "materialValue": 0,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "weight": "0.11",
+              "materialAbbreviation": "SEL3321"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2021-09-27T01:40:47.775Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-31T08:38:34.775Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:ab614d99-8c8c-4fdf-bc44-e13b521a9a82",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-261575941683097773516992",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:ab614d99-8c8c-4fdf-bc44-e13b521a9a82",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2014-11-30T21:43:35.784Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-03T22:31:01.784Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:2d8ee54d-5a7c-4157-afda-d96d0e32cbfa",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-540429593575891835848463",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:2d8ee54d-5a7c-4157-afda-d96d0e32cbfa",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2021-02-14T02:39:30.792Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-28T10:24:24.793Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:0f261333-0621-459d-8b7f-de50e61a16eb",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-681810959026920484975959",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:0f261333-0621-459d-8b7f-de50e61a16eb",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2019-04-15T18:38:45.798Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-14T17:29:24.798Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:77f4acdb-2e6e-484f-8472-e73120cd53ef",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-487243909949213496625132",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:77f4acdb-2e6e-484f-8472-e73120cd53ef",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:579b6eb3-3664-4625-bac8-b847602b1c07",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840837-48",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-783093747497706074750471",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:579b6eb3-3664-4625-bac8-b847602b1c07",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "HV MODUL",
+            "nameAtCustomer": "HV MODUL"
+          }
+        }
+      ],
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+        {
+          "component": [
+            {
+              "materialName": "Cooper",
+              "recycledContent": 0,
+              "materialClass": "3.1",
+              "quantity": {
+                "materialValue": 1.2,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CO7"
+            },
+            {
+              "materialName": "Polyamid6",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "materialValue": 2.5,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "POL6"
+            },
+            {
+              "materialName": "Carbon Steel",
+              "recycledContent": 0,
+              "materialClass": "1.1.2",
+              "quantity": {
+                "materialValue": 0.23,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CS2"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:579b6eb3-3664-4625-bac8-b847602b1c07",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 0.11,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:b174efe6-bde9-475e-9733-a0aff873e5fa"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:fe49b05c-2f64-465d-aa43-b430754bc0f4"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:320c5587-846b-4205-87df-901600046671"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:8a93c986-3e56-4732-b3db-28e7028e36c8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2015-08-02T19:00:34.854Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-27T00:10:44.854Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:b174efe6-bde9-475e-9733-a0aff873e5fa",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-322654255911224313243707",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:b174efe6-bde9-475e-9733-a0aff873e5fa",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2013-10-31T12:10:26.862Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-29T01:28:53.862Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:fe49b05c-2f64-465d-aa43-b430754bc0f4",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-098839339332321382221905",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:fe49b05c-2f64-465d-aa43-b430754bc0f4",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2018-02-24T14:24:06.869Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-25T16:55:09.869Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:320c5587-846b-4205-87df-901600046671",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-936167131531680839659122",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:320c5587-846b-4205-87df-901600046671",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2021-04-05T02:09:46.877Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-20T04:05:33.877Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:8a93c986-3e56-4732-b3db-28e7028e36c8",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-678774115901740135167003",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:8a93c986-3e56-4732-b3db-28e7028e36c8",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:d98f5071-f06f-4fa6-bec1-932dbe1ae99d",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840837-48",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-606316253832868917626071",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:d98f5071-f06f-4fa6-bec1-932dbe1ae99d",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "HV MODUL",
+            "nameAtCustomer": "HV MODUL"
+          }
+        }
+      ],
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+        {
+          "component": [
+            {
+              "materialName": "Cooper",
+              "recycledContent": 0,
+              "materialClass": "3.1",
+              "quantity": {
+                "materialValue": 1.2,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CO7"
+            },
+            {
+              "materialName": "Polyamid6",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "materialValue": 2.5,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "POL6"
+            },
+            {
+              "materialName": "Carbon Steel",
+              "recycledContent": 0,
+              "materialClass": "1.1.2",
+              "quantity": {
+                "materialValue": 0.23,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CS2"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:d98f5071-f06f-4fa6-bec1-932dbe1ae99d",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 0.11,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:7a5589a7-d5a5-4778-be7a-71205135763d"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:d2b864d9-14a6-4514-b3e9-186473c76cec"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:2e01ceb2-cb0d-4b72-ac2b-af56b1f43ac8"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:d9bc78de-9450-44aa-b224-bf0f6df56692"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:7f5966ce-bdc9-44a2-bbc6-ef0ad96711ed"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:3de58f6e-863b-4132-a947-ee3fae2dc79b"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:dd0f6c62-f22f-4ad3-b473-d428ee8cc00d"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:9185964c-8da3-4a24-a2fb-7aa5b28bbb33"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:6cd9ce9e-6411-4d3e-95ab-5825ebde9491"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:f05e990e-0997-4a58-8991-d92e86001b27"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2018-12-31T17:40:16.936Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-06T08:28:40.936Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:7a5589a7-d5a5-4778-be7a-71205135763d",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-440591586214870579110526",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:7a5589a7-d5a5-4778-be7a-71205135763d",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2013-05-25T19:27:49.944Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-08T07:33:12.944Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:d2b864d9-14a6-4514-b3e9-186473c76cec",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-422482650986590302304289",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:d2b864d9-14a6-4514-b3e9-186473c76cec",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2015-02-27T00:24:43.950Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-13T20:32:12.950Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:2e01ceb2-cb0d-4b72-ac2b-af56b1f43ac8",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-384493266483569392969895",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:2e01ceb2-cb0d-4b72-ac2b-af56b1f43ac8",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2016-01-31T01:41:58.957Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-29T14:26:28.957Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:d9bc78de-9450-44aa-b224-bf0f6df56692",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-109363089821795973633005",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:d9bc78de-9450-44aa-b224-bf0f6df56692",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2013-10-06T02:46:05.965Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-22T17:32:30.965Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:7f5966ce-bdc9-44a2-bbc6-ef0ad96711ed",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-898328229126742441341152",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:7f5966ce-bdc9-44a2-bbc6-ef0ad96711ed",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2018-06-17T23:56:36.972Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-02T10:45:29.972Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:3de58f6e-863b-4132-a947-ee3fae2dc79b",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-349504474374219652211754",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:3de58f6e-863b-4132-a947-ee3fae2dc79b",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2017-09-15T09:31:56.980Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-25T13:35:35.981Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:dd0f6c62-f22f-4ad3-b473-d428ee8cc00d",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-088196138159501420301497",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:dd0f6c62-f22f-4ad3-b473-d428ee8cc00d",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2021-04-09T16:46:44.987Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-18T10:33:39.987Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:9185964c-8da3-4a24-a2fb-7aa5b28bbb33",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-526671663042758184606201",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:9185964c-8da3-4a24-a2fb-7aa5b28bbb33",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2018-02-09T22:23:08.995Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-12T08:43:12.995Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:6cd9ce9e-6411-4d3e-95ab-5825ebde9491",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-775887537200673461307589",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:6cd9ce9e-6411-4d3e-95ab-5825ebde9491",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2015-10-31T02:19:58.002Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-24T20:40:57.002Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:f05e990e-0997-4a58-8991-d92e86001b27",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-993573480799773590841588",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:f05e990e-0997-4a58-8991-d92e86001b27",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:6d81200d-2e56-4d77-ba5a-9c3afc7b9886",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840837-48",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-129988968978834004878769",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:6d81200d-2e56-4d77-ba5a-9c3afc7b9886",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "HV MODUL",
+            "nameAtCustomer": "HV MODUL"
+          }
+        }
+      ],
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+        {
+          "component": [
+            {
+              "materialName": "Cooper",
+              "recycledContent": 0,
+              "materialClass": "3.1",
+              "quantity": {
+                "materialValue": 1.2,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CO7"
+            },
+            {
+              "materialName": "Polyamid6",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "materialValue": 2.5,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "POL6"
+            },
+            {
+              "materialName": "Carbon Steel",
+              "recycledContent": 0,
+              "materialClass": "1.1.2",
+              "quantity": {
+                "materialValue": 0.23,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CS2"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:6d81200d-2e56-4d77-ba5a-9c3afc7b9886",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 0.11,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:3356a8d5-9322-4fd7-9f89-1274849b342e"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:af369de0-a0fb-430f-a937-9c2bc51a752a"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:c2b998ce-31d1-4844-a811-cf11ada6b345"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:cdc35fc6-87ef-4878-8778-8d16b6fe6c3f"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:eeeb221c-3f3d-4668-8f13-80f97ae26633"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:f872c20e-175f-459f-896d-dad91f512e8d"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:18384cb6-abfd-487d-a676-b8b4186c3deb"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:aca2163b-b3b5-4e66-9e50-2049ec112e8f"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:73e89120-a8a7-4ee3-a135-597a315e8512"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:e31cd715-a378-4dea-86ef-44c2a09b2e5f"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2012-11-20T03:17:38.017Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-15T22:15:06.018Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:3356a8d5-9322-4fd7-9f89-1274849b342e",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-902846675862571576013658",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:3356a8d5-9322-4fd7-9f89-1274849b342e",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2016-11-16T08:26:37.026Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-19T01:59:14.026Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:af369de0-a0fb-430f-a937-9c2bc51a752a",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-296202258189647188836778",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:af369de0-a0fb-430f-a937-9c2bc51a752a",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2017-12-04T10:35:18.034Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-06T13:20:13.034Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:c2b998ce-31d1-4844-a811-cf11ada6b345",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-738627685147459436076607",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:c2b998ce-31d1-4844-a811-cf11ada6b345",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2016-02-15T17:44:10.042Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-23T19:45:05.043Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:cdc35fc6-87ef-4878-8778-8d16b6fe6c3f",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-451606954204995158383704",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:cdc35fc6-87ef-4878-8778-8d16b6fe6c3f",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2017-01-12T15:01:16.050Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-02T23:30:27.050Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:eeeb221c-3f3d-4668-8f13-80f97ae26633",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-965487094452433312086042",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:eeeb221c-3f3d-4668-8f13-80f97ae26633",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2018-06-24T09:22:01.056Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-17T23:39:38.056Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:f872c20e-175f-459f-896d-dad91f512e8d",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-690418112118634918873839",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:f872c20e-175f-459f-896d-dad91f512e8d",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2021-10-08T12:54:39.063Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-30T10:48:19.064Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:18384cb6-abfd-487d-a676-b8b4186c3deb",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-601290818336642345382840",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:18384cb6-abfd-487d-a676-b8b4186c3deb",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2021-09-23T15:12:04.070Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-12T17:34:26.070Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:aca2163b-b3b5-4e66-9e50-2049ec112e8f",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-213076289837264634708102",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:aca2163b-b3b5-4e66-9e50-2049ec112e8f",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2018-06-20T12:12:40.077Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-11T17:57:06.077Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:73e89120-a8a7-4ee3-a135-597a315e8512",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-071453623249681606958282",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:73e89120-a8a7-4ee3-a135-597a315e8512",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2016-05-04T04:54:35.084Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-08T05:48:24.084Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:e31cd715-a378-4dea-86ef-44c2a09b2e5f",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-453803324555387987807418",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:e31cd715-a378-4dea-86ef-44c2a09b2e5f",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:7c10ee16-7362-4858-8cf5-63f18c8b5a32",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840837-48",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-313664731832606149831570",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:7c10ee16-7362-4858-8cf5-63f18c8b5a32",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "HV MODUL",
+            "nameAtCustomer": "HV MODUL"
+          }
+        }
+      ],
+      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+        {
+          "component": [
+            {
+              "materialName": "Cooper",
+              "recycledContent": 0,
+              "materialClass": "3.1",
+              "quantity": {
+                "materialValue": 1.2,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CO7"
+            },
+            {
+              "materialName": "Polyamid6",
+              "recycledContent": 0,
+              "materialClass": "5.5.1",
+              "quantity": {
+                "materialValue": 2.5,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "POL6"
+            },
+            {
+              "materialName": "Carbon Steel",
+              "recycledContent": 0,
+              "materialClass": "1.1.2",
+              "quantity": {
+                "materialValue": 0.23,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "aggregateState": "solid",
+              "materialAbbreviation": "CS2"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:7c10ee16-7362-4858-8cf5-63f18c8b5a32",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 0.11,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:kilogram"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:33767611-fefb-4257-9e01-d5ddc93d5dcc"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:1f2609ce-bff9-4694-933b-b993c8d03c03"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:0594fd6a-af8b-48bb-8b11-036ca7b8605b"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:7f28c498-adab-43ee-98d8-213adfc1df9f"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:7b3889e1-33ed-4a29-8e3b-fdd736938df5"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:e3a3983a-27ae-48d3-a8c1-31b072d744ea"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:a468f8f7-1dbf-470c-9290-373f14279f98"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:d9f68a82-86b8-459d-92d5-337c81bba6c0"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:33465c01-a78f-494f-ac25-005fbcec1ef5"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
+                  "lexicalValue": "unit:piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:ed956485-fff0-4f47-98f6-2d6a5fb38182"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2020-10-19T02:52:43.100Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-14T21:54:16.100Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:33767611-fefb-4257-9e01-d5ddc93d5dcc",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-680027415336463948854137",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:33767611-fefb-4257-9e01-d5ddc93d5dcc",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2018-04-22T09:07:48.108Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-15T05:03:23.108Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:1f2609ce-bff9-4694-933b-b993c8d03c03",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-115405966341498873902861",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:1f2609ce-bff9-4694-933b-b993c8d03c03",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2013-01-04T17:19:11.116Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-25T07:08:21.116Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:0594fd6a-af8b-48bb-8b11-036ca7b8605b",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-258039045878890577998355",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:0594fd6a-af8b-48bb-8b11-036ca7b8605b",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2014-02-06T11:50:22.123Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-11T00:27:53.123Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:7f28c498-adab-43ee-98d8-213adfc1df9f",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-647621204794816812675236",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:7f28c498-adab-43ee-98d8-213adfc1df9f",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2015-01-03T11:20:47.131Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-07T17:25:01.131Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:7b3889e1-33ed-4a29-8e3b-fdd736938df5",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-682048641549094208368909",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:7b3889e1-33ed-4a29-8e3b-fdd736938df5",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2017-05-22T01:46:08.137Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-20T01:57:44.137Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:e3a3983a-27ae-48d3-a8c1-31b072d744ea",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-381433300935788596285138",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:e3a3983a-27ae-48d3-a8c1-31b072d744ea",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2017-11-05T14:12:41.146Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-25T17:15:30.146Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:a468f8f7-1dbf-470c-9290-373f14279f98",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-174878883689555771571746",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:a468f8f7-1dbf-470c-9290-373f14279f98",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2020-03-27T11:22:46.151Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-09-12T20:58:29.151Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:d9f68a82-86b8-459d-92d5-337c81bba6c0",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-418695372808577842909159",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:d9f68a82-86b8-459d-92d5-337c81bba6c0",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2020-01-21T03:11:53.158Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-23T12:03:58.158Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:33465c01-a78f-494f-ac25-005fbcec1ef5",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-762530423312223741384047",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:33465c01-a78f-494f-ac25-005fbcec1ef5",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
+        }
+      ]
+    },
+    {
+      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
+        {
+          "minimalStateOfHealth": {
+            "minimalStateOfHealthValue": "90.0",
+            "specificatorId": "OEM",
+            "minimalStateOfHealthPhase": "as specified by OEM"
+          },
+          "currentStateOfHealth": [
+            {
+              "currentStateOfHealthTimestamp": "2021-05-15T00:26:48.164Z",
+              "currentStateOfHealthPhase": "as specified by OEM",
+              "currentStateOfHealthValue": "105"
+            },
+            {
+              "currentStateOfHealthTimestamp": "2022-08-20T13:42:33.165Z",
+              "currentStateOfHealthPhase": "as recieved by dismantling",
+              "currentStateOfHealthValue": "95"
+            }
+          ],
+          "performanceIndicator": {
+            "electricCapacityMin": "0.8",
+            "electricCapacityMax": "0.88"
+          },
+          "type": "HVB"
+        }
+      ],
+      "catenaXId": "urn:uuid:ed956485-fff0-4f47-98f6-2d6a5fb38182",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "manufacturerId"
+            },
+            {
+              "value": "8840838-04",
+              "key": "manufacturerPartId"
+            },
+            {
+              "value": "NO-965428224256934920702517",
+              "key": "partInstanceId"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:ed956485-fff0-4f47-98f6-2d6a5fb38182",
+          "partTypeInformation": {
+            "manufacturerPartId": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "ZB ZELLE",
+            "nameAtCustomer": "ZB ZELLE"
+          }
+        }
+      ],
+      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+        {
+          "diameter": "32",
+          "length": "142",
+          "width": "26.5",
+          "weight": "1.4688",
+          "height": "61"
         }
       ]
     }

--- a/testdata-transform/smallTestdata.json
+++ b/testdata-transform/smallTestdata.json
@@ -1,1407 +1,39 @@
 {
   "https://catenax.io/schema/TestDataContainer/1.0.0": [
     {
-      "catenaXId": "urn:uuid:913b1530-320e-44ee-878d-9c083ecedea0",
+      "catenaXId": "urn:uuid:72589775-f8eb-48cc-ad5c-3cfe9122134b",
       "PlainObject": [
         {
           "BPN_OEM_C": "BPNL00000003AZQP",
           "BPN_SUB_TIER_B": "BPNL00000003AXS3",
           "BPN_SUB_TIER_A": "BPNL00000003B3NX",
-          "BATCH_CATHODE_1": "urn:uuid:34b31f87-8d52-4f76-891a-37b0e3b473fb",
+          "BATCH_CATHODE_1": "urn:uuid:3dcdf443-0fe7-44db-aae1-c3fcb9735535",
           "BPN_OEM_A": "BPNL00000003AYRE",
-          "BATCH_CATHODE_2": "urn:uuid:18bb4562-7d22-4ef9-9810-2307c33272e1",
+          "BATCH_CATHODE_2": "urn:uuid:8ebfca3b-9364-40e6-bb66-ffec2db34059",
           "BPN_OEM_B": "BPNL00000003AVTH",
           "BPN_IRS_TEST": "BPNL00000003AWSS",
-          "BPN_SUB_TIER_C": "BPNL00000000BJTL",
           "BPN_N_TIER_A": "BPNL00000003B0Q0",
-          "BATCH_SEALANT_1": "urn:uuid:5d2fb50e-b469-4426-a5d1-3e5822d2f51c",
-          "CREATION_DATE": "2022-09-13T19:00:33.562Z",
-          "BATCH_SEALANT_2": "urn:uuid:37c57299-789e-4922-ac82-46d1946eb9e3",
+          "BATCH_SEALANT_1": "urn:uuid:749e3f34-5cd1-41a7-a44e-f24df1dba796",
+          "CREATION_DATE": "2022-05-13T16:29:16.037Z",
+          "BATCH_SEALANT_2": "urn:uuid:f0f677ac-b6d8-4423-9716-95825dba1b0e",
           "AUTHOR": "christian.kabelin@partner.bmw.de",
-          "BATCH_GLUE_2": "urn:uuid:7ed2f7f4-ce46-4592-afd9-9061b2e38a9a",
-          "BATCH_GLUE_1": "urn:uuid:3f3a59a3-90b9-44f2-a123-498824e3e36e",
+          "BATCH_GLUE_2": "urn:uuid:d4676d63-7151-4341-b4a1-3275a4bf99f4",
+          "BATCH_GLUE_1": "urn:uuid:62c1530c-accd-42a4-972d-0a7eb2740181",
           "BPN_DISMANTLER": "BPNL00000003B6LU",
           "BPN_TIER_A": "BPNL00000003B2OM",
-          "BPN_TIER_C": "BPNL00000003CSGV",
-          "BATCH_POLYAMID_1": "urn:uuid:2fb5533c-c07e-41f1-8245-b7030b352264",
+          "BATCH_POLYAMID_1": "urn:uuid:f77e079e-5cd4-4747-bd8c-23ee8fe03d06",
           "BPN_TIER_B": "BPNL00000003B5MJ",
-          "BATCH_POLYAMID_2": "urn:uuid:73fb5246-644c-4829-9171-e9d3387d606f"
+          "BATCH_POLYAMID_2": "urn:uuid:c84977d5-d6dd-452a-9030-06aeba53a21e"
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:c1b49038-81d6-4f0f-82aa-2df1c3a6f359",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "VS-27",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "OMCVYLMEKOXCOEMCA",
-              "key": "partInstanceId"
-            },
-            {
-              "value": "OMCVYLMEKOXCOEMCA",
-              "key": "van"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2020-03-10T19:13:22.000Z",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:c1b49038-81d6-4f0f-82aa-2df1c3a6f359",
-          "partTypeInformation": {
-            "manufacturerPartId": "VS-27",
-            "classification": "product",
-            "nameAtManufacturer": "Vehicle Fully Electric"
-          }
-        }
-      ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "component": [
-            {
-              "materialName": "Iron",
-              "recycledContent": 0,
-              "materialClass": "1.1",
-              "quantity": {
-                "materialValue": 327.6,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "IR334"
-            },
-            {
-              "materialName": "Polyethylen",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "materialValue": 163.8,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "PE221"
-            },
-            {
-              "materialName": "Polyamid6",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "materialValue": 40.95,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "POL6"
-            },
-            {
-              "materialName": "Aluminium",
-              "recycledContent": 0,
-              "materialClass": "2.1",
-              "quantity": {
-                "materialValue": 286.65,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "ALU331"
-            },
-            {
-              "materialName": "Kerosene waxes and hydrocarbon waxes, oxidized, lithium salts",
-              "recycledContent": 0,
-              "materialClass": "0.7",
-              "quantity": {
-                "materialValue": 109.2,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "W123"
-            },
-            {
-              "materialName": "Glue",
-              "recycledContent": 0,
-              "materialClass": "6.2",
-              "quantity": {
-                "materialValue": 54.6,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "GL338"
-            },
-            {
-              "materialName": "Carbon Steel",
-              "recycledContent": 0,
-              "materialClass": "1.1.2",
-              "quantity": {
-                "materialValue": 382.2,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CS2"
-            },
-            {
-              "materialName": "Cooper",
-              "recycledContent": 0,
-              "materialClass": "3.1",
-              "quantity": {
-                "materialValue": 250.2,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CO7"
-            },
-            {
-              "materialName": "Rubber",
-              "recycledContent": 0,
-              "materialClass": "5.3",
-              "quantity": {
-                "materialValue": 7.8,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "R22"
-            },
-            {
-              "materialName": "Textiles",
-              "recycledContent": 0,
-              "materialClass": "5.5.2",
-              "quantity": {
-                "materialValue": 5.12,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "TEX1"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:c1b49038-81d6-4f0f-82aa-2df1c3a6f359",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:b848cfad-d0c4-4cd4-92ac-9ac6fa52e71f"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:a9abb642-5cc6-4ec1-8ea6-67a6df56733d"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:40b2bfeb-10f0-4506-9cc0-64bd0f28d105"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:251667e0-40fb-42b8-9dbb-bd6480fb7475"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:7872d5d6-d5b7-4f76-b2ed-95fd8c2a6a35"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/VehicleProductDescription/1.0.0": [
-        {
-          "bodyVariant": "Sedan",
-          "catenaXId": "urn:uuid:c1b49038-81d6-4f0f-82aa-2df1c3a6f359",
-          "engine": {
-            "size": 2998,
-            "power": 143
-          },
-          "emptyWeight": 1.73,
-          "fuel": "electric",
-          "vehicleModel": "Vehicle Fully Electric",
-          "productionDateGMT": "2010-01-01",
-          "equipmentVariants": [
-            {
-              "code": "A248B",
-              "description": "steering wheel heating",
-              "group": "special equipment"
-            }
-          ],
-          "anonymisedIdentifier": "sOMtThyhVNDWUZNRcBaQXXI",
-          "mileage": [
-            {
-              "mileagePhase": "as maintained by workshop",
-              "mileageTimestamp": "2022-04-01T20:09:59.976Z",
-              "mileageDistance": 120000
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:b848cfad-d0c4-4cd4-92ac-9ac6fa52e71f",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003CSGV",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "22782277-50",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-581727375022348614370011",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:b848cfad-d0c4-4cd4-92ac-9ac6fa52e71f",
-          "partTypeInformation": {
-            "manufacturerPartId": "22782277-50",
-            "customerPartId": "22782277-50",
-            "classification": "component",
-            "nameAtManufacturer": "Door f-l",
-            "nameAtCustomer": "Door front-left"
-          }
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:b848cfad-d0c4-4cd4-92ac-9ac6fa52e71f",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:60d621a0-4824-4b4b-8eaf-0dfaa7b64845"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:60d621a0-4824-4b4b-8eaf-0dfaa7b64845",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000000BJTL",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "95657762-59",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-318158597726962733975411",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:60d621a0-4824-4b4b-8eaf-0dfaa7b64845",
-          "partTypeInformation": {
-            "manufacturerPartId": "95657762-59",
-            "customerPartId": "95657762-59",
-            "classification": "component",
-            "nameAtManufacturer": "Door Key",
-            "nameAtCustomer": "Door Key"
-          }
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:a9abb642-5cc6-4ec1-8ea6-67a6df56733d",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003CSGV",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "95657362-64",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-081062276256899197422790",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:a9abb642-5cc6-4ec1-8ea6-67a6df56733d",
-          "partTypeInformation": {
-            "manufacturerPartId": "33740332-54",
-            "customerPartId": "33740332-54",
-            "classification": "component",
-            "nameAtManufacturer": "Door f-r",
-            "nameAtCustomer": "Door front-right"
-          }
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:a9abb642-5cc6-4ec1-8ea6-67a6df56733d",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:31b47307-1b0d-4f19-87e5-b25c147b98c1"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:31b47307-1b0d-4f19-87e5-b25c147b98c1",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000000BJTL",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "95657762-59",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-285501644942341413344914",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:31b47307-1b0d-4f19-87e5-b25c147b98c1",
-          "partTypeInformation": {
-            "manufacturerPartId": "95657762-59",
-            "customerPartId": "95657762-59",
-            "classification": "component",
-            "nameAtManufacturer": "Door Key",
-            "nameAtCustomer": "Door Key"
-          }
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:40b2bfeb-10f0-4506-9cc0-64bd0f28d105",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003B2OM",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "1O222E8-43",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-581165466695471578753351",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:40b2bfeb-10f0-4506-9cc0-64bd0f28d105",
-          "partTypeInformation": {
-            "manufacturerPartId": "1O222E8-43",
-            "customerPartId": "1O222E8-43",
-            "classification": "component",
-            "nameAtManufacturer": "Transmission",
-            "nameAtCustomer": "Transmission"
-          }
-        }
-      ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "component": [
-            {
-              "materialName": "Carbon Steel",
-              "recycledContent": 0,
-              "materialClass": "1.1.2",
-              "quantity": {
-                "materialValue": 72.843,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CS2"
-            },
-            {
-              "materialName": "Oil",
-              "recycledContent": 0,
-              "materialClass": "9.2",
-              "quantity": {
-                "materialValue": 6.9,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "liquid",
-              "materialAbbreviation": "SAE40"
-            },
-            {
-              "materialName": "Copper",
-              "recycledContent": 0,
-              "materialClass": "3.1",
-              "quantity": {
-                "materialValue": 1.2,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CO7"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:40b2bfeb-10f0-4506-9cc0-64bd0f28d105",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": "0.2014",
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:2fbd1757-1fd1-4b36-ba7b-2b29deb1c55f"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:f2cac93e-5906-44ce-b8db-dc197890d6cd"
-            },
-            {
-              "quantity": {
-                "quantityNumber": "0.2341",
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:1dbc0240-89e1-446c-aaa8-b2c3d1298eaa"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "380",
-          "length": "810",
-          "width": "590",
-          "weight": "85",
-          "height": "610"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003B0Q0",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "66586Z4-32",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-453182371085327841586911",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:2fbd1757-1fd1-4b36-ba7b-2b29deb1c55f",
-          "partTypeInformation": {
-            "manufacturerPartId": "66586Z4-32",
-            "customerPartId": "66586Z4-32",
-            "classification": "component",
-            "nameAtManufacturer": "Engineering Plastics",
-            "nameAtCustomer": "Engineering Plastics"
-          }
-        }
-      ],
-      "catenaXId": "urn:uuid:2fbd1757-1fd1-4b36-ba7b-2b29deb1c55f",
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "materialName": "Engineering Plastics",
-          "materialClass": "5.1",
-          "component": [
-            {
-              "materialName": "PA66",
-              "recycledContent": 0,
-              "materialClass": "5.1",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 70
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "PA66"
-            },
-            {
-              "materialName": "GF-Faser",
-              "recycledContent": 0,
-              "materialClass": "5.1",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 30
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "GF30"
-            }
-          ],
-          "recycledContent": 0
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:f2cac93e-5906-44ce-b8db-dc197890d6cd",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003B3NX",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "92165M0-86",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-953338478923471950094627",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:f2cac93e-5906-44ce-b8db-dc197890d6cd",
-          "partTypeInformation": {
-            "manufacturerPartId": "92165M0-86",
-            "customerPartId": "92165M0-86",
-            "classification": "component",
-            "nameAtManufacturer": "Sensor",
-            "nameAtCustomer": "Sensor"
-          }
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:f2cac93e-5906-44ce-b8db-dc197890d6cd",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": "0.1908",
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:9330b804-03ba-4b5a-93af-9a20c630501d"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003B0Q0",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "02371L9-62",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-526584782217105635478100",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:9330b804-03ba-4b5a-93af-9a20c630501d",
-          "partTypeInformation": {
-            "manufacturerPartId": "02371L9-62",
-            "customerPartId": "02371L9-62",
-            "classification": "component",
-            "nameAtManufacturer": "NTIER Product",
-            "nameAtCustomer": "NTIER Product"
-          }
-        }
-      ],
-      "catenaXId": "urn:uuid:9330b804-03ba-4b5a-93af-9a20c630501d",
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "materialName": "NTIER Product",
-          "materialClass": "5.5",
-          "component": [
-            {
-              "materialName": "Aluminium oxide",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 60
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": ""
-            },
-            {
-              "materialName": "Other",
-              "recycledContent": 0,
-              "materialClass": "5.5.2",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 40
-              },
-              "aggregateState": "",
-              "materialAbbreviation": ""
-            }
-          ],
-          "recycledContent": 0
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AXS3",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "69123K1-67",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-443885565962785719429466",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:1dbc0240-89e1-446c-aaa8-b2c3d1298eaa",
-          "partTypeInformation": {
-            "manufacturerPartId": "69123K1-67",
-            "customerPartId": "69123K1-67",
-            "classification": "component",
-            "nameAtManufacturer": "Glue",
-            "nameAtCustomer": "Glue"
-          }
-        }
-      ],
-      "catenaXId": "urn:uuid:1dbc0240-89e1-446c-aaa8-b2c3d1298eaa",
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "component": [
-            {
-              "materialName": "Glue",
-              "materialClass": "6.2",
-              "quantity": {
-                "materialValue": 0,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "weight": "0.2341",
-              "materialAbbreviation": "GL338"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:1dbc0240-89e1-446c-aaa8-b2c3d1298eaa",
-          "childParts": []
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:251667e0-40fb-42b8-9dbb-bd6480fb7475",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003B5MJ",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "21045M2-94",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-097450000156375842820501",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:251667e0-40fb-42b8-9dbb-bd6480fb7475",
-          "partTypeInformation": {
-            "manufacturerPartId": "21045M2-94",
-            "customerPartId": "21045M2-94",
-            "classification": "component",
-            "nameAtManufacturer": "ECU",
-            "nameAtCustomer": "ECU"
-          }
-        }
-      ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "component": [
-            {
-              "materialName": "Glue",
-              "recycledContent": 0,
-              "materialClass": "6.2",
-              "quantity": {
-                "materialValue": 0.3301,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "GL338"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:251667e0-40fb-42b8-9dbb-bd6480fb7475",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": "0.3301",
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:578eb7d1-63a2-4017-80c6-271dddbedfd8"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:ca629e9d-be47-4a14-a5de-dc8d19f6e4a0"
-            },
-            {
-              "quantity": {
-                "quantityNumber": "0.2001",
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:c7195ee4-675c-4a6c-877a-114103600c19"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AXS3",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "47304P9-58",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-082105746702509852353816",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:578eb7d1-63a2-4017-80c6-271dddbedfd8",
-          "partTypeInformation": {
-            "manufacturerPartId": "47304P9-58",
-            "customerPartId": "47304P9-58",
-            "classification": "component",
-            "nameAtManufacturer": "Glue",
-            "nameAtCustomer": "Glue"
-          }
-        }
-      ],
-      "catenaXId": "urn:uuid:578eb7d1-63a2-4017-80c6-271dddbedfd8",
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "materialName": "Glue",
-          "materialClass": "5.5",
-          "component": [
-            {
-              "materialName": "Aluminium oxide",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 70
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "AL7"
-            },
-            {
-              "materialName": "Other",
-              "recycledContent": 0,
-              "materialClass": "5.5.2",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 30
-              },
-              "aggregateState": "",
-              "materialAbbreviation": ""
-            }
-          ],
-          "recycledContent": 0
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:ca629e9d-be47-4a14-a5de-dc8d19f6e4a0",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003B3NX",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "36739T1-40",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-178880363412841367535223",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:ca629e9d-be47-4a14-a5de-dc8d19f6e4a0",
-          "partTypeInformation": {
-            "manufacturerPartId": "36739T1-40",
-            "customerPartId": "36739T1-40",
-            "classification": "component",
-            "nameAtManufacturer": "Sensor",
-            "nameAtCustomer": "Sensor"
-          }
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:ca629e9d-be47-4a14-a5de-dc8d19f6e4a0",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": "0.1908",
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:f3ee258d-83c3-43cf-bf94-9852fc9d5d62"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/batch/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003B0Q0",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "14830M8-91",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-090544509718531503998683",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:f3ee258d-83c3-43cf-bf94-9852fc9d5d62",
-          "partTypeInformation": {
-            "manufacturerPartId": "14830M8-91",
-            "customerPartId": "14830M8-91",
-            "classification": "component",
-            "nameAtManufacturer": "Engineering Plastics",
-            "nameAtCustomer": "Engineering Plastics"
-          }
-        }
-      ],
-      "catenaXId": "urn:uuid:f3ee258d-83c3-43cf-bf94-9852fc9d5d62",
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "materialName": "Engineering Plastics",
-          "materialClass": "5.1",
-          "component": [
-            {
-              "materialName": "PA66",
-              "recycledContent": 0,
-              "materialClass": "5.1",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 70
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "PA66"
-            },
-            {
-              "materialName": "GF-Faser",
-              "recycledContent": 0,
-              "materialClass": "5.1",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 30
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "GF30"
-            }
-          ],
-          "recycledContent": 0
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:c7195ee4-675c-4a6c-877a-114103600c19",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003B0Q0",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "72391Y8-16",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-321436075520371144418631",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:c7195ee4-675c-4a6c-877a-114103600c19",
-          "partTypeInformation": {
-            "manufacturerPartId": "72391Y8-16",
-            "customerPartId": "72391Y8-16",
-            "classification": "component",
-            "nameAtManufacturer": "Engineering Plastics",
-            "nameAtCustomer": "Engineering Plastics"
-          }
-        }
-      ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "materialName": "Engineering Plastics",
-          "materialClass": "5.1",
-          "component": [
-            {
-              "materialName": "PA66",
-              "recycledContent": 0,
-              "materialClass": "5.1",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 70
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "PA66"
-            },
-            {
-              "materialName": "GF-Faser",
-              "recycledContent": 0,
-              "materialClass": "5.1",
-              "quantity": {
-                "unit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:percent"
-                },
-                "value": 30
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "GF30"
-            }
-          ],
-          "recycledContent": 0
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:7872d5d6-d5b7-4f76-b2ed-95fd8c2a6a35",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "38049661-08",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-329231350304036846103634",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:7872d5d6-d5b7-4f76-b2ed-95fd8c2a6a35",
-          "partTypeInformation": {
-            "manufacturerPartId": "38049661-08",
-            "customerPartId": "38049661-08",
-            "classification": "component",
-            "nameAtManufacturer": "Battery",
-            "nameAtCustomer": "Battery"
-          }
-        }
-      ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "component": [
-            {
-              "materialName": "Cooper",
-              "recycledContent": 0,
-              "materialClass": "3.1",
-              "quantity": {
-                "materialValue": 5.4,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CO7"
-            },
-            {
-              "materialName": "Polyamid6",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "materialValue": 11.75,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "POL6"
-            },
-            {
-              "materialName": "Carbon Steel",
-              "recycledContent": 0,
-              "materialClass": "1.1.2",
-              "quantity": {
-                "materialValue": 1.23,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CS2"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:7872d5d6-d5b7-4f76-b2ed-95fd8c2a6a35",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:9afe9e1b-a7e4-4fa0-81c6-6968278a755e"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:3ea62eb9-de33-485f-921d-f6420e449646"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:579b6eb3-3664-4625-bac8-b847602b1c07"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:d98f5071-f06f-4fa6-bec1-932dbe1ae99d"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:6d81200d-2e56-4d77-ba5a-9c3afc7b9886"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:7c10ee16-7362-4858-8cf5-63f18c8b5a32"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/ReturnRequest/0.1.1": [
+      "https://catenax.io/schema/CertificateOfDestruction/1.0.0": [
         {
           "productConditions": "at least 1990 model",
+          "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
           "desiredPrice": {
-            "cost": 15340,
+            "cost": 6.770644E37,
             "currency": "EUR"
           },
           "returnConditions": "Wishes to buy",
@@ -1409,997 +41,1882 @@
           "needsReturn": true,
           "latestReturnDate": "2025-01-01"
         }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:9afe9e1b-a7e4-4fa0-81c6-6968278a755e",
+      ],
+      "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
+              "key": "ManufacturerID"
             },
             {
-              "value": "8840837-48",
-              "key": "manufacturerPartId"
+              "value": "KR-09",
+              "key": "ManufacturerPartID"
             },
             {
-              "value": "NO-390644514189558711866299",
-              "key": "partInstanceId"
+              "value": "OMA-TGFAYUHXFLHHUQQMPLTE",
+              "key": "PartInstanceID"
+            },
+            {
+              "value": "OMA-TGFAYUHXFLHHUQQMPLTE",
+              "key": "VAN"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2014-11-18T09:23:55.000Z",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
+          "partTypeInformation": {
+            "manufacturerPartID": "KR-09",
+            "classification": "product",
+            "nameAtManufacturer": "Vehicle Hybrid"
+          }
+        }
+      ],
+      "https://catenax.io/schema/AAS/3.0": [
+        {
+          "identification": "urn:uuid:e4040df4-0163-4235-96eb-a369beed51e6",
+          "idShort": "vehicle_hybrid.asm",
+          "specificAssetIds": [
+            {
+              "value": "OMA-TGFAYUHXFLHHUQQMPLTE",
+              "key": "http://pwc.t-systems.com/datamodel/common"
+            },
+            {
+              "value": "KR-09",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003AYRE"
+            }
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "Vehicle Hybrid"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003AYRE.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003AYRE/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "assemblyPartRelationship",
+              "idShort": "assembly-part-relationship"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb"
+            ]
+          }
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
+                  "lexicalValue": "piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
+                  "lexicalValue": "piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc"
+            },
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
+                  "lexicalValue": "piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003B2OM",
+              "key": "ManufacturerID"
+            },
+            {
+              "value": "1O222E8-43",
+              "key": "ManufacturerPartID"
+            },
+            {
+              "value": "NO-733616531805581150452604",
+              "key": "PartInstanceID"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:9afe9e1b-a7e4-4fa0-81c6-6968278a755e",
+          "catenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562",
           "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
+            "manufacturerPartID": "1O222E8-43",
+            "customerPartId": "1O222E8-43",
             "classification": "component",
-            "nameAtManufacturer": "HV MODUL",
-            "nameAtCustomer": "HV MODUL"
+            "nameAtManufacturer": "Transmission",
+            "nameAtCustomer": "Transmission"
           }
         }
       ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+      "https://catenax.io/schema/AAS/3.0": [
         {
-          "component": [
+          "identification": "urn:uuid:e7f913e3-cc08-42e6-a8b4-20aa5562b2a3",
+          "idShort": "transmission.asm",
+          "specificAssetIds": [
             {
-              "materialName": "Cooper",
-              "recycledContent": 0,
-              "materialClass": "3.1",
-              "quantity": {
-                "materialValue": 1.2,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CO7"
+              "value": "NO-733616531805581150452604",
+              "key": "http://pwc.t-systems.com/datamodel/common"
             },
             {
-              "materialName": "Polyamid6",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "materialValue": 2.5,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "POL6"
+              "value": "1O222E8-43",
+              "key": "urn:VR:wt.part.WTPart#"
             },
             {
-              "materialName": "Carbon Steel",
-              "recycledContent": 0,
-              "materialClass": "1.1.2",
-              "quantity": {
-                "materialValue": 0.23,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CS2"
+              "key": "ManufacturerId",
+              "value": "BPNL00000003B2OM"
             }
-          ]
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "Transmission"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "assemblyPartRelationship",
+              "idShort": "assembly-part-relationship"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562"
+            ]
+          }
         }
       ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:9afe9e1b-a7e4-4fa0-81c6-6968278a755e",
+          "catenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562",
           "childParts": [
             {
               "quantity": {
-                "quantityNumber": 0.11,
+                "quantityNumber": "0.2014",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
+                  "lexicalValue": "kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf"
+              "childCatenaXId": "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae"
             },
             {
               "quantity": {
                 "quantityNumber": 1,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
+                  "lexicalValue": "piece"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:24bdb582-944b-45e9-80ab-062474e5e7d7"
+              "childCatenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2"
             },
             {
               "quantity": {
-                "quantityNumber": 1,
+                "quantityNumber": "0.2341",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
+                  "lexicalValue": "kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:d0d289a1-a54a-4ccb-a21c-70e7037f4243"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:43cf3ca4-20d5-4c54-8fa9-0a43c2d966c4"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:c0e2bde1-b406-4d98-9a92-5be8d3b83099"
+              "childCatenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef"
             }
           ]
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
         }
       ]
     },
     {
-      "https://catenax.io/schema/batch/1.0.0": [
+      "catenaXId": "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003B0Q0",
+              "key": "ManufacturerID"
+            },
+            {
+              "value": "01697F7-65",
+              "key": "ManufacturerPartID"
+            },
+            {
+              "value": "NO-947880349904267845729159",
+              "key": "PartInstanceID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae",
+          "partTypeInformation": {
+            "manufacturerPartID": "01697F7-65",
+            "customerPartId": "01697F7-65",
+            "classification": "component",
+            "nameAtManufacturer": "Engineering Plastics",
+            "nameAtCustomer": "Engineering Plastics"
+          }
+        }
+      ],
+      "https://catenax.io/schema/AAS/3.0": [
+        {
+          "identification": "urn:uuid:af63a726-bc49-47e5-b9f0-d1f42f000791",
+          "idShort": "engineering_plastics.asm",
+          "specificAssetIds": [
+            {
+              "value": "NO-947880349904267845729159",
+              "key": "http://pwc.t-systems.com/datamodel/common"
+            },
+            {
+              "value": "01697F7-65",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003B0Q0"
+            }
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "Engineering Plastics"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae"
+            ]
+          }
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003B3NX",
+              "key": "ManufacturerID"
+            },
+            {
+              "value": "37754B7-76",
+              "key": "ManufacturerPartID"
+            },
+            {
+              "value": "NO-159040131155901488695376",
+              "key": "PartInstanceID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2",
+          "partTypeInformation": {
+            "manufacturerPartID": "37754B7-76",
+            "customerPartId": "37754B7-76",
+            "classification": "component",
+            "nameAtManufacturer": "Sensor",
+            "nameAtCustomer": "Sensor"
+          }
+        }
+      ],
+      "https://catenax.io/schema/AAS/3.0": [
+        {
+          "identification": "urn:uuid:ed6f38ce-2c96-458d-a15a-3966e05de942",
+          "idShort": "sensor.asm",
+          "specificAssetIds": [
+            {
+              "value": "NO-159040131155901488695376",
+              "key": "http://pwc.t-systems.com/datamodel/common"
+            },
+            {
+              "value": "37754B7-76",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003B3NX"
+            }
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "Sensor"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B3NX.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B3NX/urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "assemblyPartRelationship",
+              "idShort": "assembly-part-relationship"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2"
+            ]
+          }
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": "0.1908",
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
+                  "lexicalValue": "kilogram"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003B0Q0",
+              "key": "ManufacturerID"
+            },
+            {
+              "value": "98801V5-17",
+              "key": "ManufacturerPartID"
+            },
+            {
+              "value": "NO-056604022229087145032390",
+              "key": "PartInstanceID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31",
+          "partTypeInformation": {
+            "manufacturerPartID": "98801V5-17",
+            "customerPartId": "98801V5-17",
+            "classification": "component",
+            "nameAtManufacturer": "NTIER Product",
+            "nameAtCustomer": "NTIER Product"
+          }
+        }
+      ],
+      "https://catenax.io/schema/AAS/3.0": [
+        {
+          "identification": "urn:uuid:367922d4-ee3a-40a3-b0f9-8e34c5a2ab51",
+          "idShort": "ntier_product.asm",
+          "specificAssetIds": [
+            {
+              "value": "NO-056604022229087145032390",
+              "key": "http://pwc.t-systems.com/datamodel/common"
+            },
+            {
+              "value": "98801V5-17",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003B0Q0"
+            }
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "NTIER Product"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31"
+            ]
+          }
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:f7cf62fe-9e25-472b-9148-66ebcc291f31",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003AXS3",
-              "key": "manufacturerId"
+              "key": "ManufacturerID"
             },
             {
-              "value": "9A047C7-01",
-              "key": "manufacturerPartId"
+              "value": "31008B0-49",
+              "key": "ManufacturerPartID"
             },
             {
-              "value": "NO-931692691590612649332063",
-              "key": "partInstanceId"
+              "value": "NO-825423826078402432465664",
+              "key": "PartInstanceID"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf",
+          "catenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef",
           "partTypeInformation": {
-            "manufacturerPartId": "9A047C7-01",
-            "customerPartId": "9A047C7-01",
+            "manufacturerPartID": "31008B0-49",
+            "customerPartId": "31008B0-49",
             "classification": "component",
-            "nameAtManufacturer": "Sealant",
-            "nameAtCustomer": "Sealant"
+            "nameAtManufacturer": "Glue",
+            "nameAtCustomer": "Glue"
           }
         }
       ],
-      "catenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf",
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+      "https://catenax.io/schema/AAS/3.0": [
         {
-          "component": [
+          "identification": "urn:uuid:48af44a2-e853-4b4f-a311-95794f542696",
+          "idShort": "glue.asm",
+          "specificAssetIds": [
             {
-              "materialName": "Sealant",
-              "materialClass": "6.3",
-              "quantity": {
-                "materialValue": 0,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "weight": "0.11",
-              "materialAbbreviation": "SEL3321"
+              "value": "NO-825423826078402432465664",
+              "key": "http://pwc.t-systems.com/datamodel/common"
+            },
+            {
+              "value": "31008B0-49",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003AXS3"
             }
-          ]
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "Glue"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003AXS3.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003AXS3/urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "assemblyPartRelationship",
+              "idShort": "assembly-part-relationship"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef"
+            ]
+          }
         }
       ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf"
+          "catenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef",
+          "childParts": []
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
         }
       ]
     },
     {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2012-11-07T08:35:40.695Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-03T20:48:12.696Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:24bdb582-944b-45e9-80ab-062474e5e7d7",
+      "catenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
+              "value": "BPNL00000003B5MJ",
+              "key": "ManufacturerID"
             },
             {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
+              "value": "83238F4-36",
+              "key": "ManufacturerPartID"
             },
             {
-              "value": "NO-301915402074061381393752",
-              "key": "partInstanceId"
+              "value": "NO-354879221683258717359442",
+              "key": "PartInstanceID"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:24bdb582-944b-45e9-80ab-062474e5e7d7",
+          "catenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc",
           "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
+            "manufacturerPartID": "83238F4-36",
+            "customerPartId": "83238F4-36",
             "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
+            "nameAtManufacturer": "ECU",
+            "nameAtCustomer": "ECU"
           }
         }
       ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+      "https://catenax.io/schema/AAS/3.0": [
         {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
+          "identification": "urn:uuid:8f2b558a-62f8-44f1-b2e4-6b5ad4bbbfd9",
+          "idShort": "ecu.asm",
+          "specificAssetIds": [
             {
-              "currentStateOfHealthTimestamp": "2017-01-15T08:31:26.703Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
+              "value": "NO-354879221683258717359442",
+              "key": "http://pwc.t-systems.com/datamodel/common"
             },
             {
-              "currentStateOfHealthTimestamp": "2022-08-17T17:35:14.703Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
+              "value": "83238F4-36",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003B5MJ"
             }
           ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:d0d289a1-a54a-4ccb-a21c-70e7037f4243",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
+          "description": [
             {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-820523752865804896998892",
-              "key": "partInstanceId"
+              "language": "en",
+              "text": "ECU"
             }
           ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:d0d289a1-a54a-4ccb-a21c-70e7037f4243",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
+          "submodelDescriptors": [
             {
-              "currentStateOfHealthTimestamp": "2017-01-06T02:55:52.710Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-09T19:18:11.710Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:43cf3ca4-20d5-4c54-8fa9-0a43c2d966c4",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-743319028656688478281705",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:43cf3ca4-20d5-4c54-8fa9-0a43c2d966c4",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2014-07-22T10:56:01.716Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-04T06:14:39.716Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:c0e2bde1-b406-4d98-9a92-5be8d3b83099",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-239258021244659013481041",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:c0e2bde1-b406-4d98-9a92-5be8d3b83099",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:3ea62eb9-de33-485f-921d-f6420e449646",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840837-48",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-712848562793023650626166",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:3ea62eb9-de33-485f-921d-f6420e449646",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "HV MODUL",
-            "nameAtCustomer": "HV MODUL"
-          }
-        }
-      ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "component": [
-            {
-              "materialName": "Cooper",
-              "recycledContent": 0,
-              "materialClass": "3.1",
-              "quantity": {
-                "materialValue": 1.2,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
                 }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CO7"
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B5MJ.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B5MJ/urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "assemblyPartRelationship",
+              "idShort": "assembly-part-relationship"
             },
             {
-              "materialName": "Polyamid6",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "materialValue": 2.5,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
                 }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "POL6"
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
             },
             {
-              "materialName": "Carbon Steel",
-              "recycledContent": 0,
-              "materialClass": "1.1.2",
-              "quantity": {
-                "materialValue": 0.23,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
                 }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CS2"
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
             }
-          ]
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc"
+            ]
+          }
         }
       ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:3ea62eb9-de33-485f-921d-f6420e449646",
+          "catenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc",
           "childParts": [
             {
               "quantity": {
-                "quantityNumber": 0.11,
+                "quantityNumber": "0.3301",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
+                  "lexicalValue": "kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
+              "childCatenaXId": "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34"
             },
             {
               "quantity": {
                 "quantityNumber": 1,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
+                  "lexicalValue": "piece"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:ab614d99-8c8c-4fdf-bc44-e13b521a9a82"
+              "childCatenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640"
             },
             {
               "quantity": {
-                "quantityNumber": 1,
+                "quantityNumber": "0.2001",
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
+                  "lexicalValue": "kilogram"
                 }
               },
               "lifecycleContext": "AsBuilt",
               "assembledOn": "2022-02-03T14:48:54.709Z",
               "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:2d8ee54d-5a7c-4157-afda-d96d0e32cbfa"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:0f261333-0621-459d-8b7f-de50e61a16eb"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:77f4acdb-2e6e-484f-8472-e73120cd53ef"
+              "childCatenaXId": "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87"
             }
           ]
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:6dafbcec-2fce-4cbb-a5a9-b3b32aa5cffc",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
         }
       ]
     },
     {
-      "https://catenax.io/schema/batch/1.0.0": [
+      "catenaXId": "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003AXS3",
-              "key": "manufacturerId"
+              "key": "ManufacturerID"
             },
             {
-              "value": "9A047C7-01",
-              "key": "manufacturerPartId"
+              "value": "91471Z0-84",
+              "key": "ManufacturerPartID"
             },
             {
-              "value": "NO-170808344553200705971613",
-              "key": "partInstanceId"
+              "value": "NO-182660425740222655242543",
+              "key": "PartInstanceID"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420",
+          "catenaXId": "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34",
           "partTypeInformation": {
-            "manufacturerPartId": "9A047C7-01",
-            "customerPartId": "9A047C7-01",
+            "manufacturerPartID": "91471Z0-84",
+            "customerPartId": "91471Z0-84",
             "classification": "component",
-            "nameAtManufacturer": "Sealant",
-            "nameAtCustomer": "Sealant"
+            "nameAtManufacturer": "Glue",
+            "nameAtCustomer": "Glue"
           }
         }
       ],
-      "catenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420",
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+      "https://catenax.io/schema/AAS/3.0": [
         {
-          "component": [
+          "identification": "urn:uuid:918f8caa-d613-4f4a-8711-8c86bf0989ab",
+          "idShort": "glue.asm",
+          "specificAssetIds": [
             {
-              "materialName": "Sealant",
-              "materialClass": "6.3",
-              "quantity": {
-                "materialValue": 0,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "weight": "0.11",
-              "materialAbbreviation": "SEL3321"
+              "value": "NO-182660425740222655242543",
+              "key": "http://pwc.t-systems.com/datamodel/common"
+            },
+            {
+              "value": "91471Z0-84",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003AXS3"
             }
-          ]
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "Glue"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34"
+            ]
+          }
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:b931e9e8-614d-494c-a8e6-548ee8b6ef34",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003B3NX",
+              "key": "ManufacturerID"
+            },
+            {
+              "value": "65847F9-69",
+              "key": "ManufacturerPartID"
+            },
+            {
+              "value": "NO-628797496367807957077265",
+              "key": "PartInstanceID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640",
+          "partTypeInformation": {
+            "manufacturerPartID": "65847F9-69",
+            "customerPartId": "65847F9-69",
+            "classification": "component",
+            "nameAtManufacturer": "Sensor",
+            "nameAtCustomer": "Sensor"
+          }
+        }
+      ],
+      "https://catenax.io/schema/AAS/3.0": [
+        {
+          "identification": "urn:uuid:f8a3a7f6-6817-41fa-8f0b-8dc4d6db003f",
+          "idShort": "sensor.asm",
+          "specificAssetIds": [
+            {
+              "value": "NO-628797496367807957077265",
+              "key": "http://pwc.t-systems.com/datamodel/common"
+            },
+            {
+              "value": "65847F9-69",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003B3NX"
+            }
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "Sensor"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B3NX.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B3NX/urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "assemblyPartRelationship",
+              "idShort": "assembly-part-relationship"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640"
+            ]
+          }
         }
       ],
       "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
         {
-          "catenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
+          "catenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": "0.1908",
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
+                  "lexicalValue": "kilogram"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:1ae94880-e6b0-4bf3-ab74-8148b63c0640",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
         }
       ]
     },
     {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2021-09-27T01:40:47.775Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-31T08:38:34.775Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:ab614d99-8c8c-4fdf-bc44-e13b521a9a82",
+      "catenaXId": "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
+              "value": "BPNL00000003B0Q0",
+              "key": "ManufacturerID"
             },
             {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
+              "value": "74268H5-13",
+              "key": "ManufacturerPartID"
             },
             {
-              "value": "NO-261575941683097773516992",
-              "key": "partInstanceId"
+              "value": "NO-565359302028822441908953",
+              "key": "PartInstanceID"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:ab614d99-8c8c-4fdf-bc44-e13b521a9a82",
+          "catenaXId": "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9",
           "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
+            "manufacturerPartID": "74268H5-13",
+            "customerPartId": "74268H5-13",
             "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
+            "nameAtManufacturer": "Engineering Plastics",
+            "nameAtCustomer": "Engineering Plastics"
           }
         }
       ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+      "https://catenax.io/schema/AAS/3.0": [
         {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
+          "identification": "urn:uuid:e51ac8ed-f7b3-49fd-a781-b5c5d16b623e",
+          "idShort": "engineering_plastics.asm",
+          "specificAssetIds": [
             {
-              "currentStateOfHealthTimestamp": "2014-11-30T21:43:35.784Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
+              "value": "NO-565359302028822441908953",
+              "key": "http://pwc.t-systems.com/datamodel/common"
             },
             {
-              "currentStateOfHealthTimestamp": "2022-09-03T22:31:01.784Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
+              "value": "74268H5-13",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003B0Q0"
             }
           ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:2d8ee54d-5a7c-4157-afda-d96d0e32cbfa",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
+          "description": [
             {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-540429593575891835848463",
-              "key": "partInstanceId"
+              "language": "en",
+              "text": "Engineering Plastics"
             }
           ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:2d8ee54d-5a7c-4157-afda-d96d0e32cbfa",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9"
+            ]
           }
         }
       ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+      "https://catenax.io/schema/Batch/1.0.0": [
         {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:186359fb-4584-40e4-a59b-ed842d3d80d9",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
         }
       ]
     },
     {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2021-02-14T02:39:30.792Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-28T10:24:24.793Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:0f261333-0621-459d-8b7f-de50e61a16eb",
+      "catenaXId": "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
+              "value": "BPNL00000003B0Q0",
+              "key": "ManufacturerID"
             },
             {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
+              "value": "55269I8-71",
+              "key": "ManufacturerPartID"
             },
             {
-              "value": "NO-681810959026920484975959",
-              "key": "partInstanceId"
+              "value": "NO-340460948192054950891951",
+              "key": "PartInstanceID"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:0f261333-0621-459d-8b7f-de50e61a16eb",
+          "catenaXId": "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87",
           "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
+            "manufacturerPartID": "55269I8-71",
+            "customerPartId": "55269I8-71",
             "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
+            "nameAtManufacturer": "Engineering Plastics",
+            "nameAtCustomer": "Engineering Plastics"
           }
         }
       ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+      "https://catenax.io/schema/AAS/3.0": [
         {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
+          "identification": "urn:uuid:2b47d838-4bbe-4867-951a-83192e3f4e2f",
+          "idShort": "engineering_plastics.asm",
+          "specificAssetIds": [
             {
-              "currentStateOfHealthTimestamp": "2019-04-15T18:38:45.798Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
+              "value": "NO-340460948192054950891951",
+              "key": "http://pwc.t-systems.com/datamodel/common"
             },
             {
-              "currentStateOfHealthTimestamp": "2022-08-14T17:29:24.798Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
+              "value": "55269I8-71",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003B0Q0"
             }
           ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:77f4acdb-2e6e-484f-8472-e73120cd53ef",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
+          "description": [
             {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-487243909949213496625132",
-              "key": "partInstanceId"
+              "language": "en",
+              "text": "Engineering Plastics"
             }
           ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:77f4acdb-2e6e-484f-8472-e73120cd53ef",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87"
+            ]
           }
         }
       ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
+      "https://catenax.io/schema/Batch/1.0.0": [
         {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:8b59e2ec-d76a-49a7-a795-c4bea4a02d87",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
         }
       ]
     },
     {
-      "catenaXId": "urn:uuid:579b6eb3-3664-4625-bac8-b847602b1c07",
+      "catenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a",
       "https://catenax.io/schema/SerialPartTypization/1.0.0": [
         {
           "localIdentifiers": [
             {
               "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
+              "key": "ManufacturerID"
             },
             {
-              "value": "8840837-48",
-              "key": "manufacturerPartId"
+              "value": "95657362-83",
+              "key": "ManufacturerPartID"
             },
             {
-              "value": "NO-783093747497706074750471",
-              "key": "partInstanceId"
+              "value": "NO-369202025208677072946181",
+              "key": "PartInstanceID"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
             "country": "DEU"
           },
-          "catenaXId": "urn:uuid:579b6eb3-3664-4625-bac8-b847602b1c07",
+          "catenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a",
           "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
+            "manufacturerPartID": "95657362-83",
+            "customerPartId": "95657362-83",
+            "classification": "component",
+            "nameAtManufacturer": "Battery",
+            "nameAtCustomer": "Battery"
+          }
+        }
+      ],
+      "https://catenax.io/schema/AAS/3.0": [
+        {
+          "identification": "urn:uuid:80d060c6-4f79-490a-8a8c-ec230bff786c",
+          "idShort": "battery.asm",
+          "specificAssetIds": [
+            {
+              "value": "NO-369202025208677072946181",
+              "key": "http://pwc.t-systems.com/datamodel/common"
+            },
+            {
+              "value": "95657362-83",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003AYRE"
+            }
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "Battery"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003AYRE.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003AYRE/urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "assemblyPartRelationship",
+              "idShort": "assembly-part-relationship"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a"
+            ]
+          }
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a",
+          "childParts": [
+            {
+              "quantity": {
+                "quantityNumber": 1,
+                "measurementUnit": {
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#piece",
+                  "lexicalValue": "piece"
+                }
+              },
+              "lifecycleContext": "AsBuilt",
+              "assembledOn": "2022-02-03T14:48:54.709Z",
+              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
+              "childCatenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:587cfb38-7149-4f06-b1e0-0e9b6e98be2a",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "ManufacturerID"
+            },
+            {
+              "value": "8840838-04",
+              "key": "ManufacturerPartID"
+            },
+            {
+              "value": "NO-397646649734958738335866",
+              "key": "PartInstanceID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978",
+          "partTypeInformation": {
+            "manufacturerPartID": "8840838-04",
             "customerPartId": "8840838-04",
             "classification": "component",
             "nameAtManufacturer": "HV MODUL",
@@ -2407,8 +1924,231 @@
           }
         }
       ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
+      "https://catenax.io/schema/AAS/3.0": [
         {
+          "identification": "urn:uuid:9ec14d43-c009-464a-9717-86cf28d4df28",
+          "idShort": "hv_modul.asm",
+          "specificAssetIds": [
+            {
+              "value": "NO-397646649734958738335866",
+              "key": "http://pwc.t-systems.com/datamodel/common"
+            },
+            {
+              "value": "8840838-04",
+              "key": "urn:VR:wt.part.WTPart#"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003AYRE"
+            }
+          ],
+          "description": [
+            {
+              "language": "en",
+              "text": "HV MODUL"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003AYRE.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003AYRE/urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "assemblyPartRelationship",
+              "idShort": "assembly-part-relationship"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.serial_part_typization:1.0.0#SerialPartTypization"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "serialPartTypization",
+              "idShort": "serial-part-typization"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978"
+            ]
+          }
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978",
+          "childParts": []
+        }
+      ],
+      "https://catenax.io/schema/Batch/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BID12345678",
+              "key": "BatchID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "HUR"
+          },
+          "catenaXId": "urn:uuid:fe99da3d-b0de-4e80-81da-882aebcca978",
+          "partTypeInformation": {
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
+          }
+        }
+      ]
+    },
+    {
+      "catenaXId": "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa",
+      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+        {
+          "localIdentifiers": [
+            {
+              "value": "BPNL00000003AYRE",
+              "key": "ManufacturerID"
+            },
+            {
+              "value": "8840838-04",
+              "key": "ManufacturerPartID"
+            },
+            {
+              "value": "NO-397646649734958738335866",
+              "key": "PartInstanceID"
+            }
+          ],
+          "manufacturingInformation": {
+            "date": "2022-02-04T14:48:54",
+            "country": "DEU"
+          },
+          "catenaXId": "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa",
+          "partTypeInformation": {
+            "manufacturerPartID": "8840838-04",
+            "customerPartId": "8840838-04",
+            "classification": "component",
+            "nameAtManufacturer": "HV MODUL",
+            "nameAtCustomer": "HV MODUL"
+          }
+        }
+      ],
+      "https://catenax.io/schema/AAS/3.0": [
+        {
+          "description": [
+            {
+              "language": "en",
+              "text": "HV MODUL"
+            }
+          ],
+          "globalAssetId": {
+            "value": [
+              "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa"
+            ]
+          },
+          "idShort": "hv_modul.asm",
+          "identification": "urn:uuid:9ec14d43-c009-464a-9717-86cf28d4df28",
+          "specificAssetIds": [
+            {
+              "key": "http://pwc.t-systems.com/datamodel/common",
+              "value": "NO-397646649734958738335866"
+            },
+            {
+              "key": "urn:VR:wt.part.WTPart#",
+              "value": "8840838-04"
+            },
+            {
+              "key": "ManufacturerId",
+              "value": "BPNL00000003AYRE"
+            }
+          ],
+          "submodelDescriptors": [
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.assembly_part_relationship:1.0.0"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003AYRE.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider-control-plane:8282/BPNL00000003AYRE/urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa-urn:uuid:3064f87d-5e4a-496b-9685-c1cf3e113198/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "urn:uuid:3064f87d-5e4a-496b-9685-c1cf3e113198",
+              "idShort": "assembly-part-relationship"
+            },
+            {
+              "semanticId": [
+                {
+                  "value": "urn:bamm:com.catenax.batch:1.0.0#Batch"
+                }
+              ],
+              "endpoints": [
+                {
+                  "interface": "https://BPNL00000003B2OM.connector",
+                  "protocolInformation": {
+                    "endpointAddress": "http://provider.connector:port/BPNL00000003B2OM/urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb-urn:uuid:23685ed-75cc-2a40-3a13-792a8bb2/submodel?content=value&extent=WithBLOBValue",
+                    "endpointProtocolVersion": "1.0RC02",
+                    "endpointProtocol": "AAS/SUBMODEL"
+                  }
+                }
+              ],
+              "identification": "batch",
+              "idShort": "batch"
+            }
+          ]
+        }
+      ],
+      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
+        {
+          "catenaXId": "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa",
           "component": [
             {
               "materialName": "Cooper",
@@ -2417,8 +2157,8 @@
               "quantity": {
                 "materialValue": 1.2,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
+                  "lexicalValue": "kilogram"
                 }
               },
               "aggregateState": "solid",
@@ -2431,8 +2171,8 @@
               "quantity": {
                 "materialValue": 2.5,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
+                  "lexicalValue": "kilogram"
                 }
               },
               "aggregateState": "solid",
@@ -2445,8 +2185,8 @@
               "quantity": {
                 "materialValue": 0.23,
                 "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
+                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#kilogram",
+                  "lexicalValue": "kilogram"
                 }
               },
               "aggregateState": "solid",
@@ -2455,3081 +2195,26 @@
           ]
         }
       ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:579b6eb3-3664-4625-bac8-b847602b1c07",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": 0.11,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:6728649b-f8a6-4468-89aa-447cfd276dbf"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:b174efe6-bde9-475e-9733-a0aff873e5fa"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:fe49b05c-2f64-465d-aa43-b430754bc0f4"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:320c5587-846b-4205-87df-901600046671"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:8a93c986-3e56-4732-b3db-28e7028e36c8"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2015-08-02T19:00:34.854Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-27T00:10:44.854Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:b174efe6-bde9-475e-9733-a0aff873e5fa",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
+      "https://catenax.io/schema/Batch/1.0.0": [
         {
           "localIdentifiers": [
             {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-322654255911224313243707",
-              "key": "partInstanceId"
+              "value": "BID12345678",
+              "key": "BatchID"
             }
           ],
           "manufacturingInformation": {
             "date": "2022-02-04T14:48:54",
-            "country": "DEU"
+            "country": "HUR"
           },
-          "catenaXId": "urn:uuid:b174efe6-bde9-475e-9733-a0aff873e5fa",
+          "catenaXId": "urn:uuid:5f479670-0b9a-475f-88e9-30f3558eb5aa",
           "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
+            "manufacturerPartId": "123-0.740-3434-A",
+            "customerPartId": "PRT-12345",
+            "classification": "product",
+            "nameAtManufacturer": "Mirror left",
+            "nameAtCustomer": "side element A"
           }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2013-10-31T12:10:26.862Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-29T01:28:53.862Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:fe49b05c-2f64-465d-aa43-b430754bc0f4",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-098839339332321382221905",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:fe49b05c-2f64-465d-aa43-b430754bc0f4",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2018-02-24T14:24:06.869Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-25T16:55:09.869Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:320c5587-846b-4205-87df-901600046671",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-936167131531680839659122",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:320c5587-846b-4205-87df-901600046671",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2021-04-05T02:09:46.877Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-20T04:05:33.877Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:8a93c986-3e56-4732-b3db-28e7028e36c8",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-678774115901740135167003",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:8a93c986-3e56-4732-b3db-28e7028e36c8",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:d98f5071-f06f-4fa6-bec1-932dbe1ae99d",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840837-48",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-606316253832868917626071",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:d98f5071-f06f-4fa6-bec1-932dbe1ae99d",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "HV MODUL",
-            "nameAtCustomer": "HV MODUL"
-          }
-        }
-      ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "component": [
-            {
-              "materialName": "Cooper",
-              "recycledContent": 0,
-              "materialClass": "3.1",
-              "quantity": {
-                "materialValue": 1.2,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CO7"
-            },
-            {
-              "materialName": "Polyamid6",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "materialValue": 2.5,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "POL6"
-            },
-            {
-              "materialName": "Carbon Steel",
-              "recycledContent": 0,
-              "materialClass": "1.1.2",
-              "quantity": {
-                "materialValue": 0.23,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CS2"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:d98f5071-f06f-4fa6-bec1-932dbe1ae99d",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": 0.11,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:7a5589a7-d5a5-4778-be7a-71205135763d"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:d2b864d9-14a6-4514-b3e9-186473c76cec"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:2e01ceb2-cb0d-4b72-ac2b-af56b1f43ac8"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:d9bc78de-9450-44aa-b224-bf0f6df56692"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:7f5966ce-bdc9-44a2-bbc6-ef0ad96711ed"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:3de58f6e-863b-4132-a947-ee3fae2dc79b"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:dd0f6c62-f22f-4ad3-b473-d428ee8cc00d"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:9185964c-8da3-4a24-a2fb-7aa5b28bbb33"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:6cd9ce9e-6411-4d3e-95ab-5825ebde9491"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:f05e990e-0997-4a58-8991-d92e86001b27"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2018-12-31T17:40:16.936Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-06T08:28:40.936Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:7a5589a7-d5a5-4778-be7a-71205135763d",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-440591586214870579110526",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:7a5589a7-d5a5-4778-be7a-71205135763d",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2013-05-25T19:27:49.944Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-08T07:33:12.944Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:d2b864d9-14a6-4514-b3e9-186473c76cec",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-422482650986590302304289",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:d2b864d9-14a6-4514-b3e9-186473c76cec",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2015-02-27T00:24:43.950Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-13T20:32:12.950Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:2e01ceb2-cb0d-4b72-ac2b-af56b1f43ac8",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-384493266483569392969895",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:2e01ceb2-cb0d-4b72-ac2b-af56b1f43ac8",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2016-01-31T01:41:58.957Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-29T14:26:28.957Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:d9bc78de-9450-44aa-b224-bf0f6df56692",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-109363089821795973633005",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:d9bc78de-9450-44aa-b224-bf0f6df56692",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2013-10-06T02:46:05.965Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-22T17:32:30.965Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:7f5966ce-bdc9-44a2-bbc6-ef0ad96711ed",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-898328229126742441341152",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:7f5966ce-bdc9-44a2-bbc6-ef0ad96711ed",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2018-06-17T23:56:36.972Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-02T10:45:29.972Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:3de58f6e-863b-4132-a947-ee3fae2dc79b",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-349504474374219652211754",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:3de58f6e-863b-4132-a947-ee3fae2dc79b",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2017-09-15T09:31:56.980Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-25T13:35:35.981Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:dd0f6c62-f22f-4ad3-b473-d428ee8cc00d",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-088196138159501420301497",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:dd0f6c62-f22f-4ad3-b473-d428ee8cc00d",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2021-04-09T16:46:44.987Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-18T10:33:39.987Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:9185964c-8da3-4a24-a2fb-7aa5b28bbb33",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-526671663042758184606201",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:9185964c-8da3-4a24-a2fb-7aa5b28bbb33",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2018-02-09T22:23:08.995Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-12T08:43:12.995Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:6cd9ce9e-6411-4d3e-95ab-5825ebde9491",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-775887537200673461307589",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:6cd9ce9e-6411-4d3e-95ab-5825ebde9491",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2015-10-31T02:19:58.002Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-24T20:40:57.002Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:f05e990e-0997-4a58-8991-d92e86001b27",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-993573480799773590841588",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:f05e990e-0997-4a58-8991-d92e86001b27",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:6d81200d-2e56-4d77-ba5a-9c3afc7b9886",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840837-48",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-129988968978834004878769",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:6d81200d-2e56-4d77-ba5a-9c3afc7b9886",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "HV MODUL",
-            "nameAtCustomer": "HV MODUL"
-          }
-        }
-      ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "component": [
-            {
-              "materialName": "Cooper",
-              "recycledContent": 0,
-              "materialClass": "3.1",
-              "quantity": {
-                "materialValue": 1.2,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CO7"
-            },
-            {
-              "materialName": "Polyamid6",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "materialValue": 2.5,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "POL6"
-            },
-            {
-              "materialName": "Carbon Steel",
-              "recycledContent": 0,
-              "materialClass": "1.1.2",
-              "quantity": {
-                "materialValue": 0.23,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CS2"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:6d81200d-2e56-4d77-ba5a-9c3afc7b9886",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": 0.11,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:3356a8d5-9322-4fd7-9f89-1274849b342e"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:af369de0-a0fb-430f-a937-9c2bc51a752a"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:c2b998ce-31d1-4844-a811-cf11ada6b345"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:cdc35fc6-87ef-4878-8778-8d16b6fe6c3f"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:eeeb221c-3f3d-4668-8f13-80f97ae26633"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:f872c20e-175f-459f-896d-dad91f512e8d"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:18384cb6-abfd-487d-a676-b8b4186c3deb"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:aca2163b-b3b5-4e66-9e50-2049ec112e8f"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:73e89120-a8a7-4ee3-a135-597a315e8512"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:e31cd715-a378-4dea-86ef-44c2a09b2e5f"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2012-11-20T03:17:38.017Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-15T22:15:06.018Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:3356a8d5-9322-4fd7-9f89-1274849b342e",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-902846675862571576013658",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:3356a8d5-9322-4fd7-9f89-1274849b342e",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2016-11-16T08:26:37.026Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-19T01:59:14.026Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:af369de0-a0fb-430f-a937-9c2bc51a752a",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-296202258189647188836778",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:af369de0-a0fb-430f-a937-9c2bc51a752a",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2017-12-04T10:35:18.034Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-06T13:20:13.034Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:c2b998ce-31d1-4844-a811-cf11ada6b345",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-738627685147459436076607",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:c2b998ce-31d1-4844-a811-cf11ada6b345",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2016-02-15T17:44:10.042Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-23T19:45:05.043Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:cdc35fc6-87ef-4878-8778-8d16b6fe6c3f",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-451606954204995158383704",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:cdc35fc6-87ef-4878-8778-8d16b6fe6c3f",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2017-01-12T15:01:16.050Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-02T23:30:27.050Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:eeeb221c-3f3d-4668-8f13-80f97ae26633",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-965487094452433312086042",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:eeeb221c-3f3d-4668-8f13-80f97ae26633",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2018-06-24T09:22:01.056Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-17T23:39:38.056Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:f872c20e-175f-459f-896d-dad91f512e8d",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-690418112118634918873839",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:f872c20e-175f-459f-896d-dad91f512e8d",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2021-10-08T12:54:39.063Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-30T10:48:19.064Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:18384cb6-abfd-487d-a676-b8b4186c3deb",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-601290818336642345382840",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:18384cb6-abfd-487d-a676-b8b4186c3deb",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2021-09-23T15:12:04.070Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-12T17:34:26.070Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:aca2163b-b3b5-4e66-9e50-2049ec112e8f",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-213076289837264634708102",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:aca2163b-b3b5-4e66-9e50-2049ec112e8f",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2018-06-20T12:12:40.077Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-11T17:57:06.077Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:73e89120-a8a7-4ee3-a135-597a315e8512",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-071453623249681606958282",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:73e89120-a8a7-4ee3-a135-597a315e8512",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2016-05-04T04:54:35.084Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-08T05:48:24.084Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:e31cd715-a378-4dea-86ef-44c2a09b2e5f",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-453803324555387987807418",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:e31cd715-a378-4dea-86ef-44c2a09b2e5f",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "catenaXId": "urn:uuid:7c10ee16-7362-4858-8cf5-63f18c8b5a32",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840837-48",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-313664731832606149831570",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:7c10ee16-7362-4858-8cf5-63f18c8b5a32",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "HV MODUL",
-            "nameAtCustomer": "HV MODUL"
-          }
-        }
-      ],
-      "https://catenax.io/schema/MaterialForRecycling/1.1.0": [
-        {
-          "component": [
-            {
-              "materialName": "Cooper",
-              "recycledContent": 0,
-              "materialClass": "3.1",
-              "quantity": {
-                "materialValue": 1.2,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CO7"
-            },
-            {
-              "materialName": "Polyamid6",
-              "recycledContent": 0,
-              "materialClass": "5.5.1",
-              "quantity": {
-                "materialValue": 2.5,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "POL6"
-            },
-            {
-              "materialName": "Carbon Steel",
-              "recycledContent": 0,
-              "materialClass": "1.1.2",
-              "quantity": {
-                "materialValue": 0.23,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "aggregateState": "solid",
-              "materialAbbreviation": "CS2"
-            }
-          ]
-        }
-      ],
-      "https://catenax.io/schema/AssemblyPartRelationship/1.0.0": [
-        {
-          "catenaXId": "urn:uuid:7c10ee16-7362-4858-8cf5-63f18c8b5a32",
-          "childParts": [
-            {
-              "quantity": {
-                "quantityNumber": 0.11,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:kilogram"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:74ff9322-b06e-4ac1-9af2-6b59a8f7d420"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:33767611-fefb-4257-9e01-d5ddc93d5dcc"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:1f2609ce-bff9-4694-933b-b993c8d03c03"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:0594fd6a-af8b-48bb-8b11-036ca7b8605b"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:7f28c498-adab-43ee-98d8-213adfc1df9f"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:7b3889e1-33ed-4a29-8e3b-fdd736938df5"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:e3a3983a-27ae-48d3-a8c1-31b072d744ea"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:a468f8f7-1dbf-470c-9290-373f14279f98"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:d9f68a82-86b8-459d-92d5-337c81bba6c0"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:33465c01-a78f-494f-ac25-005fbcec1ef5"
-            },
-            {
-              "quantity": {
-                "quantityNumber": 1,
-                "measurementUnit": {
-                  "datatypeURI": "urn:bamm:io.openmanufacturing:meta-model:1.0.0#curie",
-                  "lexicalValue": "unit:piece"
-                }
-              },
-              "lifecycleContext": "AsBuilt",
-              "assembledOn": "2022-02-03T14:48:54.709Z",
-              "lastModifiedOn": "2022-02-03T14:48:54.709Z",
-              "childCatenaXId": "urn:uuid:ed956485-fff0-4f47-98f6-2d6a5fb38182"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2020-10-19T02:52:43.100Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-14T21:54:16.100Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:33767611-fefb-4257-9e01-d5ddc93d5dcc",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-680027415336463948854137",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:33767611-fefb-4257-9e01-d5ddc93d5dcc",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2018-04-22T09:07:48.108Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-15T05:03:23.108Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:1f2609ce-bff9-4694-933b-b993c8d03c03",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-115405966341498873902861",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:1f2609ce-bff9-4694-933b-b993c8d03c03",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2013-01-04T17:19:11.116Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-25T07:08:21.116Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:0594fd6a-af8b-48bb-8b11-036ca7b8605b",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-258039045878890577998355",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:0594fd6a-af8b-48bb-8b11-036ca7b8605b",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2014-02-06T11:50:22.123Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-11T00:27:53.123Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:7f28c498-adab-43ee-98d8-213adfc1df9f",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-647621204794816812675236",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:7f28c498-adab-43ee-98d8-213adfc1df9f",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2015-01-03T11:20:47.131Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-07T17:25:01.131Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:7b3889e1-33ed-4a29-8e3b-fdd736938df5",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-682048641549094208368909",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:7b3889e1-33ed-4a29-8e3b-fdd736938df5",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2017-05-22T01:46:08.137Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-20T01:57:44.137Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:e3a3983a-27ae-48d3-a8c1-31b072d744ea",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-381433300935788596285138",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:e3a3983a-27ae-48d3-a8c1-31b072d744ea",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2017-11-05T14:12:41.146Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-25T17:15:30.146Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:a468f8f7-1dbf-470c-9290-373f14279f98",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-174878883689555771571746",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:a468f8f7-1dbf-470c-9290-373f14279f98",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2020-03-27T11:22:46.151Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-09-12T20:58:29.151Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:d9f68a82-86b8-459d-92d5-337c81bba6c0",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-418695372808577842909159",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:d9f68a82-86b8-459d-92d5-337c81bba6c0",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2020-01-21T03:11:53.158Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-23T12:03:58.158Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:33465c01-a78f-494f-ac25-005fbcec1ef5",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-762530423312223741384047",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:33465c01-a78f-494f-ac25-005fbcec1ef5",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
-        }
-      ]
-    },
-    {
-      "https://catenax.io/schema/BatteryProductDescription/1.0.1": [
-        {
-          "minimalStateOfHealth": {
-            "minimalStateOfHealthValue": "90.0",
-            "specificatorId": "OEM",
-            "minimalStateOfHealthPhase": "as specified by OEM"
-          },
-          "currentStateOfHealth": [
-            {
-              "currentStateOfHealthTimestamp": "2021-05-15T00:26:48.164Z",
-              "currentStateOfHealthPhase": "as specified by OEM",
-              "currentStateOfHealthValue": "105"
-            },
-            {
-              "currentStateOfHealthTimestamp": "2022-08-20T13:42:33.165Z",
-              "currentStateOfHealthPhase": "as recieved by dismantling",
-              "currentStateOfHealthValue": "95"
-            }
-          ],
-          "performanceIndicator": {
-            "electricCapacityMin": "0.8",
-            "electricCapacityMax": "0.88"
-          },
-          "type": "HVB"
-        }
-      ],
-      "catenaXId": "urn:uuid:ed956485-fff0-4f47-98f6-2d6a5fb38182",
-      "https://catenax.io/schema/SerialPartTypization/1.0.0": [
-        {
-          "localIdentifiers": [
-            {
-              "value": "BPNL00000003AYRE",
-              "key": "manufacturerId"
-            },
-            {
-              "value": "8840838-04",
-              "key": "manufacturerPartId"
-            },
-            {
-              "value": "NO-965428224256934920702517",
-              "key": "partInstanceId"
-            }
-          ],
-          "manufacturingInformation": {
-            "date": "2022-02-04T14:48:54",
-            "country": "DEU"
-          },
-          "catenaXId": "urn:uuid:ed956485-fff0-4f47-98f6-2d6a5fb38182",
-          "partTypeInformation": {
-            "manufacturerPartId": "8840838-04",
-            "customerPartId": "8840838-04",
-            "classification": "component",
-            "nameAtManufacturer": "ZB ZELLE",
-            "nameAtCustomer": "ZB ZELLE"
-          }
-        }
-      ],
-      "https://catenax.io/schema/PhysicalDimension/1.0.0": [
-        {
-          "diameter": "32",
-          "length": "142",
-          "width": "26.5",
-          "weight": "1.4688",
-          "height": "61"
         }
       ]
     }

--- a/testdata-transform/transform-and-upload.py
+++ b/testdata-transform/transform-and-upload.py
@@ -187,8 +187,6 @@ if __name__ == "__main__":
     edc_policy_path = "/data/policydefinitions"
     edc_contract_definition_path = "/data/contractdefinitions"
 
-    # esr_url = "https://irs-esr.dev.demo.catena-x.net/esr/esr-statistics/"
-
     headers = {
         'Content-Type': 'application/json'
     }
@@ -275,11 +273,11 @@ if __name__ == "__main__":
         for tmp_key in tmp_keys:
             if tmp_key not in ("PlainObject", "catenaXId"):
                 # 1. Prepare submodel endpoint address
-                if part_bpn == submodel_server_1_bpn:
+                if contract_id % 3 == 0:
                     submodel_url = submodel_server_1_address
                     edc_url = edc_url1
                     statistic_dict.update({"provider1": statistic_dict["provider1"] + 1})
-                elif part_bpn == submodel_server_2_bpn:
+                elif contract_id % 3 == 1:
                     submodel_url = submodel_server_2_address
                     edc_url = edc_url2
                     statistic_dict.update({"provider2": statistic_dict["provider2"] + 1})

--- a/testdata-transform/transform-and-upload.py
+++ b/testdata-transform/transform-and-upload.py
@@ -271,7 +271,8 @@ if __name__ == "__main__":
             tmp_data.update({"https://catenax.io/schema/EsrCertificateStateStatistic/1.0.1": ""})
 
         for tmp_key in tmp_keys:
-            if tmp_key not in ("PlainObject", "catenaXId"):
+            if tmp_key not in ("PlainObject", "catenaXId", "https://catenax.io/schema/PhysicalDimension/1.0.0",
+                               "https://catenax.io/schema/BatteryProductDescription/1.0.1"):
                 # 1. Prepare submodel endpoint address
                 if contract_id % 3 == 0:
                     submodel_url = submodel_server_1_address

--- a/testdata-transform/transform-and-upload.py
+++ b/testdata-transform/transform-and-upload.py
@@ -10,6 +10,7 @@ import re
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+
 def create_submodel_payload(json_payload):
     return json.dumps(json_payload)
 
@@ -211,7 +212,8 @@ if __name__ == "__main__":
         "ReturnRequest": "urn:bamm:io.catenax.return_request:1.0.0#ReturnRequest",
         "PhysicalDimension": "urn:bamm:io.catenax.physical_dimension:1.0.0#PhysicalDimension",
         "batch": "urn:bamm:io.catenax.batch:1.0.0#Batch",
-        "EsrCertificateStateStatistic": "urn:bamm:io.catenax.esr_certificates.esr_certificate_state_statistic:1.0.1#EsrCertificateStateStatistic"
+        "EsrCertificateStateStatistic":
+            "urn:bamm:io.catenax.esr_certificates.esr_certificate_state_statistic:1.0.1#EsrCertificateStateStatistic"
     }
 
     contract_id = 1
@@ -250,7 +252,8 @@ if __name__ == "__main__":
             if tmp_key in "https://catenax.io/schema/batch/1.0.0" \
                     or tmp_key in "https://catenax.io/schema/SerialPartTypization/1.0.0":
                 specific_asset_ids = tmp_data[tmp_key][0]["localIdentifiers"]
-                name_at_manufacturer = tmp_data[tmp_key][0]["partTypeInformation"]["nameAtManufacturer"].replace(" ","")
+                name_at_manufacturer = tmp_data[tmp_key][0]["partTypeInformation"]["nameAtManufacturer"]\
+                    .replace(" ", "")
         print(name_at_manufacturer)
 
         part_bpn = ""
@@ -258,7 +261,7 @@ if __name__ == "__main__":
             if specific_asset_id.get("key") == "manufacturerId":
                 part_bpn = specific_asset_id.get("value")
 
-        if esr_url is not None:
+        if esr_url:
             tmp_data.update({"https://catenax.io/schema/EsrCertificateStateStatistic/1.0.1": ""})
 
         for tmp_key in tmp_keys:


### PR DESCRIPTION
https://jira.catena-x.net/browse/TRI-611
- Update test data set to 1.3.2
- Rework upload script to use data from the set set directly
- Rework upload script to generate aas shells
- Rework reset script to clear the registry and edc completely