### PR TITLE
fix(cucumber):[-] Add support for empty testset

### DIFF
--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           export HTTP_RESULT=$(curl -s --show-error -w "%{http_code}" -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11349&fz=true" -o features.zip)
           [[ $HTTP_RESULT == 200 || $HTTP_RESULT == 400 ]]
-          echo "::set-output name=http_response::${{ env.HTTP_RESULT }}"
+          echo "::set-output name=http_response::$HTTP_RESULT"
 
       - name: Build with Maven
         if: ${{ steps.download.outputs.http_response == '200' }}

--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -34,13 +34,15 @@ jobs:
           # JIRA filter 11349: project = TRI AND type = Test AND "Test Type" = Cucumber
           # Downloads all feature files of cucumber tests inside TRI project
         run: |
-          echo "::set-output name=http_response::$(curl -s -w "%{http_code}" -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11349&fz=true" -o features.zip)"
-          
-          unzip -o features.zip -d cucumber-tests/src/test/resources/features || true
+          export HTTP_RESULT=$(curl -s -w "%{http_code}" -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11349&fz=true" -o features.zip)
+          [[ $HTTP_RESULT == 200 || $HTTP_RESULT == 400 ]]
+          echo "::set-output name=http_response::${{ env.HTTP_RESULT }}"
 
       - name: Build with Maven
         if: ${{ steps.download.outputs.http_response == '200' }}
-        run: mvn --batch-mode clean compile test -pl cucumber-tests
+        run: |
+          unzip -o features.zip -d cucumber-tests/src/test/resources/features
+          mvn --batch-mode clean compile test -pl cucumber-tests
 
       - name: Submit results to Xray
         if: ${{ steps.download.outputs.http_response == '200' }}

--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -38,11 +38,11 @@ jobs:
           unzip -o features.zip -d cucumber-tests/src/test/resources/features || true
 
       - name: Build with Maven
-        if: ${{ steps.download.http_response }} == 200
+        if: ${{ steps.download.http_response == '200' }}
         run: mvn --batch-mode clean compile test -pl cucumber-tests
 
       - name: Submit results to Xray
-        if: ${{ steps.download.http_response }} == 200
+        if: ${{ steps.download.http_response == '200' }}
         env:
           JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
           JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}

--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -34,7 +34,7 @@ jobs:
           # JIRA filter 11349: project = TRI AND type = Test AND "Test Type" = Cucumber
           # Downloads all feature files of cucumber tests inside TRI project
         run: |
-          export HTTP_RESULT=$(curl -s -w "%{http_code}" -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11349&fz=true" -o features.zip)
+          export HTTP_RESULT=$(curl -s --show-error -w "%{http_code}" -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11349&fz=true" -o features.zip)
           [[ $HTTP_RESULT == 200 || $HTTP_RESULT == 400 ]]
           echo "::set-output name=http_response::${{ env.HTTP_RESULT }}"
 

--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -35,14 +35,15 @@ jobs:
           # Downloads all feature files of cucumber tests inside TRI project
         run: |
           echo "::set-output name=http_response::$(curl -s -w "%{http_code}" -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11349&fz=true" -o features.zip)"
+          
           unzip -o features.zip -d cucumber-tests/src/test/resources/features || true
 
       - name: Build with Maven
-        if: ${{ steps.download.http_response == '200' }}
+        if: ${{ steps.download.outputs.http_response == '200' }}
         run: mvn --batch-mode clean compile test -pl cucumber-tests
 
       - name: Submit results to Xray
-        if: ${{ steps.download.http_response == '200' }}
+        if: ${{ steps.download.outputs.http_response == '200' }}
         env:
           JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
           JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}

--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -27,19 +27,22 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Download Feature Files
+        id: download
         env:
           JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
           JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
           # JIRA filter 11349: project = TRI AND type = Test AND "Test Type" = Cucumber
           # Downloads all feature files of cucumber tests inside TRI project
         run: |
-          curl -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11349&fz=true" -o features.zip
-          unzip -o features.zip -d cucumber-tests/src/test/resources/features
+          echo "::set-output name=http_response::$(curl -s -w "%{http_code}" -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11349&fz=true" -o features.zip)"
+          unzip -o features.zip -d cucumber-tests/src/test/resources/features || true
 
       - name: Build with Maven
+        if: ${{ steps.download.http_response }} == 200
         run: mvn --batch-mode clean compile test -pl cucumber-tests
 
       - name: Submit results to Xray
+        if: ${{ steps.download.http_response }} == 200
         env:
           JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
           JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}


### PR DESCRIPTION
If download fails (statuscode != 200), the execution steps are skipped.