### PR TITLE
Fix/revert helm chart release update

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -36,9 +36,7 @@ jobs:
           helm dependency update
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
-        with:
-          charts_dir: charts/
+        uses: luisico/chart-releaser-action@on-tags
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "{{ .Name }}-helm-charts-{{ .Version }}"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -29,6 +29,12 @@ jobs:
         with:
           version: v3.8.1
 
+      - name: Update helm dependencies for irs
+        run: |
+          cd charts/irs
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm dependency update
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1
         with:

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1
         with:
-          config: ci/cr.yaml
           charts_dir: charts/
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          RELEASE_NAME_TEMPLATE: "{{ .Name }}-helm-charts-{{ .Version }}"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -41,4 +41,4 @@ jobs:
           charts_dir: charts/
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          RELEASE_NAME_TEMPLATE: "{{ .Name }}-helm-charts-{{ .Version }}"
+          CR_RELEASE_NAME_TEMPLATE: "{{ .Name }}-helm-charts-{{ .Version }}"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -29,14 +29,8 @@ jobs:
         with:
           version: v3.8.1
 
-      - name: Update helm dependencies for irs
-        run: |
-          cd charts/irs
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm dependency update
-
       - name: Run chart-releaser
-        uses: luisico/chart-releaser-action@on-tags
+        uses: helm/chart-releaser-action@v1.4.1
         with:
           config: ci/cr.yaml
           charts_dir: charts/

--- a/ci/cr.yaml
+++ b/ci/cr.yaml
@@ -1,1 +1,0 @@
-release-name-template: {{ .Name }}-helm-charts-{{ .Version }}


### PR DESCRIPTION
Fixed workflow run by adding CR_RELEASE_NAME_TEMPLATE as env var instead of config file entry