### PR TITLE
fix(hsts):[-] Always send HSTS header, not only on HTTPS requests

### DIFF
--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/SecurityConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/SecurityConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -70,7 +71,10 @@ public class SecurityConfiguration {
                     .httpStrictTransportSecurity()
                     .maxAgeInSeconds(Duration.ofDays(HSTS_MAX_AGE_DAYS).toSeconds())
                     .includeSubDomains(true)
-                    .preload(true);
+                    .preload(true)
+                    .requestMatcher(AnyRequestMatcher.INSTANCE);
+
+        httpSecurity.headers().xssProtection().xssProtectionEnabled(true).block(true);
 
         httpSecurity.headers().frameOptions().sameOrigin();
 


### PR DESCRIPTION
When IRS runs behind an ingress, Spring does not know that the connection is encrypted. Due to this, we need to enforce the header on all requests. Also it includes the XSS protection header.