### PR TITLE
fix(owasp):[-] Update to Spring Boot 2.7.4; suppress irrelevant finding

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -86,6 +86,7 @@ jobs:
           output: "trivy-results2.sarif"
           exit-code: "1"
           severity: "CRITICAL,HIGH"
+          trivyignores: ci/.trivyignore
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()

--- a/ci/.trivyignore
+++ b/ci/.trivyignore
@@ -1,0 +1,2 @@
+# Only relevant if UNWRAP_SINGLE_VALUE_ARRAYS is activated, which is not the case here.
+CVE-2022-42003

--- a/ci/owasp-suppressions.xml
+++ b/ci/owasp-suppressions.xml
@@ -67,4 +67,11 @@
         <gav regex="true">org\.yaml:snakeyaml.*</gav>
         <vulnerabilityName>CVE-2022-38752</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Only relevant if UNWRAP_SINGLE_VALUE_ARRAYS is activated, which is not the case here.
+        ]]></notes>
+        <gav regex="true">com\.fasterxml\.jackson\.core:jackson-databind.*</gav>
+        <vulnerabilityName>CVE-2022-42003</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -27,6 +27,18 @@
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
             <version>8.4.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Update jackson-databind manually to avoid vulnerability CVE-2022-42004; can be removed after Minio updates their dependency -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.4</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         </sonar.coverage.jacoco.xmlReportPaths>
 
         <!-- Dependencies -->
-        <springboot.version>2.7.3</springboot.version>
+        <springboot.version>2.7.4</springboot.version>
         <springcloud-feign.version>3.1.4</springcloud-feign.version>
         <springdoc.version>1.6.7</springdoc.version>
         <micrometer.version>1.9.5</micrometer.version>


### PR DESCRIPTION
CVE-2022-42003 is suppressed now for OWASP and trivy