### PR TITLE
feat(cucumber):[TRI-767] Add separate integration test pipeline

### DIFF
--- a/.github/workflows/xray-cucumber-integration.yaml
+++ b/.github/workflows/xray-cucumber-integration.yaml
@@ -1,8 +1,10 @@
-name: IRS Cucumber Xray execution
+name: IRS Cucumber Integration test Xray execution
 
 on:
   workflow_dispatch:
   push:
+    branches:
+      - 'main'
 
 jobs:
   build:
@@ -46,7 +48,7 @@ jobs:
           IRS_DEV: https://irs.dev.demo.catena-x.net
         run: |
           unzip -o features.zip -d cucumber-tests/src/test/resources/features
-          mvn --batch-mode clean install -pl cucumber-tests,irs-models -D"cucumber.filter.tags"="not @Ignore and not @INTEGRATION_TEST"
+          mvn --batch-mode clean install -pl cucumber-tests,irs-models -D"cucumber.filter.tags"="not @Ignore and @INTEGRATION_TEST"
 
       - name: Submit results to Xray
         if: ${{ always() && steps.download.outputs.http_response == '200' }}


### PR DESCRIPTION
Moved integration test execution to separate action which gets executed only on push to main. Excluded `@INTEGRATION_TEST` from cucumber execution on branches