### PR TITLE
chore(dependency):[-] Update spring security core / oauth2-resource-s…

### DIFF
--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -110,6 +110,12 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
             <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
             <version>5.7.5</version>
@@ -117,6 +123,18 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-resource-server</artifactId>
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-core</artifactId>
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
             <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
             <version>5.7.5</version>
         </dependency>

--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -90,6 +90,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+
+
+        <!-- ############################################################################ -->
+        <!-- MANUAL SPRING UPDATES - CHECK WHEN UPDATING SPRING BOOT IF NECESSARY ANYMORE -->
+        <!-- ############################################################################ -->
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-client</artifactId>
@@ -138,6 +143,17 @@
             <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
             <version>5.7.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <!-- ############################################################################ -->
+        <!-- MANUAL SPRING UPDATES - CHECK WHEN UPDATING SPRING BOOT IF NECESSARY ANYMORE -->
+        <!-- ############################################################################ -->
+
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>

--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -98,6 +98,18 @@
             <version>5.7.5</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
             <version>${springcloud-feign.version}</version>

--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -22,6 +22,11 @@
         </repository>
     </repositories>
 
+    <properties>
+        <!-- version override due to CVEs, can be removed once Spring Boot BOM contains new version -->
+        <spring-security.version>5.7.5</spring-security.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.minio</groupId>
@@ -87,26 +92,8 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-client</artifactId>
-            <!-- version override due to CVE-2022-31690, can be removed once Spring Boot BOM contains new version -->
-            <version>5.7.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-web</artifactId>
-            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
-            <version>5.7.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-core</artifactId>
-            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
-            <version>5.7.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-resource-server</artifactId>
-            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <!-- version override due to CVE, can be removed once Spring Boot BOM contains new version -->
             <version>5.7.5</version>
         </dependency>
         <dependency>

--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -23,7 +23,7 @@
     </repositories>
 
     <properties>
-        <!-- version override due to CVEs, can be removed once Spring Boot BOM contains new version -->
+        <!-- version override due to CVE, can be removed once Spring Boot BOM contains new version -->
         <spring-security.version>5.7.5</spring-security.version>
     </properties>
 
@@ -92,8 +92,32 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
+            <!-- version override due to CVE-2022-31690, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
+            <version>5.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-resource-server</artifactId>
-            <!-- version override due to CVE, can be removed once Spring Boot BOM contains new version -->
+            <!-- version override due to CVE-2022-31692, can be removed once Spring Boot BOM contains new version -->
             <version>5.7.5</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
I force-updated all Spring Security libraries to 5.7.5. This can be removed as soon as the spring boot security starters are available for the version.