### PR TITLE
fix(impl):[TRI-851] - fix creating tombstone when shouldnt

### DIFF
--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegateTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/aaswrapper/job/delegate/BpdmDelegateTest.java
@@ -140,6 +140,22 @@ class BpdmDelegateTest {
                 ProcessStep.BPDM_REQUEST);
     }
 
+    @Test
+    void shouldNotCreateBpnsAndTombstonesIfShellIsMissing() {
+        // given
+        final ItemContainer.ItemContainerBuilder itemContainerWithoutShell = ItemContainer.builder();
+
+        // when
+        final ItemContainer result = bpdmDelegate.process(itemContainerWithoutShell, jobParameter(),
+                new AASTransferProcess(), "itemId");
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getShells()).isEmpty();
+        assertThat(result.getBpns()).isEmpty();
+        assertThat(result.getTombstones()).isEmpty();
+    }
+
     private ItemContainer.ItemContainerBuilder itemContainerWithAssetId(String key, String value) {
         return ItemContainer.builder().shell(
                 AssetAdministrationShellDescriptor


### PR DESCRIPTION
If shell is missing for globalAssetId tombstone is already created inside DigitalTwinDelegate, so creating second one in BpdmDelegate was a bug.