### PR TITLE
Revert "chore(deps): bump jackson-databind from 2.13.4.2 to 2.14.0"

### DIFF
--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.0</version>
+            <version>2.13.4.2</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
This reverts commit a6ddcb316c67630f4403d9bb18077a7d64672dca.